### PR TITLE
Feature - force completion at block level

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -28,7 +28,18 @@ define(function(require) {
                 this.$('.mejs-container').width(this.$('.component-widget').width());
             }
         },
-
+        
+        forceBlockCompletion: function(){
+            //
+            var siblings = this.model.getSiblings(false);
+            
+            siblings.each(function(model){
+                //set to complete
+                model.set('_isComplete', true);
+            });
+            //
+        },
+ 
         postRender: function() {
             var mediaElement = this.$('audio, video').mediaelementplayer({
                 pluginPath:'assets/',
@@ -76,6 +87,10 @@ define(function(require) {
 
         onCompletion: function() {
             this.setCompletionStatus();
+            
+            if(this.model.get('_forceBlockCompletion'))
+                this.forceBlockCompletion();
+            
             // removeEventListener needs to pass in the method to remove the event in firefox and IE10
             this.mediaElement.removeEventListener(this.completionEvent, this.onCompletion);
         },


### PR DESCRIPTION
When there is a need to have a block with a set of video components but only one is enough to trigger completion this addition will resolve this. `_forceBlockCompletion` in the media model sets this feature on or off.