### PR TITLE
Force Block level completion

### DIFF
--- a/example.json
+++ b/example.json
@@ -10,6 +10,7 @@
 	"body": "This is optional body text. Select the play button to start the video.",
 	"instruction": "",
 	"_setCompletionOn":"inview",
+        "_forceBlockCompletion":true,
 	"_media": {
 		"mp4": "course/assets/big_buck_bunny.mp4",
 		"ogv": "course/assets/big_buck_bunny.ogv",

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -28,7 +28,17 @@ define(function(require) {
                 this.$('.mejs-container').width(this.$('.component-widget').width());
             }
         },
-
+        
+        forceBlockCompletion: function(){
+            //
+            var siblings = this.model.getSiblings(false);
+            
+            siblings.each(function(model){
+                //set to complete
+                model.set('_isComplete', true);
+            });
+            //
+        },
         postRender: function() {
             var mediaElement = this.$('audio, video').mediaelementplayer({
                 pluginPath:'assets/',
@@ -76,6 +86,10 @@ define(function(require) {
 
         onCompletion: function() {
             this.setCompletionStatus();
+            
+            if(this.model.get('_forceBlockCompletion'))
+                this.forceBlockCompletion();
+            
             // removeEventListener needs to pass in the method to remove the event in firefox and IE10
             this.mediaElement.removeEventListener(this.completionEvent, this.onCompletion);
         },


### PR DESCRIPTION
Feature to set block level completion - useful when there is few media components and just anyone should trigger completion.

This should be used with the "_setCompletionOn":"play", as the function is called in the `onCompletion` handler only.