### PR TITLE
a to button

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -54,6 +54,7 @@
     }
 
     .media-external-transcript-button, .media-inline-transcript-button {
+        width:100%;
         display:block;
     }
 }

--- a/templates/media.hbs
+++ b/templates/media.hbs
@@ -28,7 +28,7 @@
 
       <div class="media-transcript-button-container">
         {{#if _transcript._inlineTranscript}}
-          <a href="#" class="media-inline-transcript-button button" role="button">
+          <button class="base media-inline-transcript-button button" role="button">
             <div class="transcript-text-container">
               {{#if _transcript.inlineTranscriptButton}}
                 {{_transcript.inlineTranscriptButton}}
@@ -36,10 +36,10 @@
                 {{_transcript.transcriptLink}}
               {{/if}}
             </div>
-          </a>
+          </button>
         {{/if}}
         {{#if _transcript._externalTranscript}}
-          <a href="{{_transcript.transcriptLink}}" target="_blank" class="media-external-transcript-button button" role="button">
+          <button onclick="window.open('{{_transcript.transcriptLink}}')" class="base media-external-transcript-button button" role="button">
             <div class="transcript-text-container">
               {{#if _transcript.transcriptLinkButton}}
                 {{_transcript.transcriptLinkButton}}
@@ -47,7 +47,7 @@
                 {{_transcript.transcriptLink}}
               {{/if}}
             </div>
-          </a>
+          </button>
         {{/if}}
         </div>
 


### PR DESCRIPTION
Since a is changed to button, width gets reduced. So it is set to 100% in media-inline-transcript-button class