### PR TITLE
issue-1231: give vimeo mejs-container tabbing

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -216,8 +216,18 @@ define(function(require) {
                 this.setupPlayPauseToggle();
             }
 
+            this.addThirdPartyAfterFixes();
+
             this.setReadyStatus();
             this.setupEventListeners();
+        },
+
+        addThirdPartyAfterFixes: function() {
+            var media = this.model.get("_media");
+            switch (media.type) {
+            case "video/vimeo":
+                this.$(".mejs-container").attr("tabindex", 0);
+            }
         },
 
         onScreenSizeChanged: function() {


### PR DESCRIPTION
* onPlayerReady doesn't callback until the video video is visible onscreen

this makes it tabbable when it does callback