### PR TITLE
Removed the protocol from streaming services

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -40,6 +40,16 @@ define(function(require) {
             this.listenTo(Adapt, 'device:changed', this.onDeviceChanged);
             this.listenTo(Adapt, 'accessibility:toggle', this.onAccessibilityToggle);
 
+            if (this.model.get('_media').source) {
+                // Remove the protocol for streaming service.
+                // This prevents conflicts with HTTP/HTTPS
+                var media = this.model.get('_media');
+
+                media.source = media.source.replace(/^https?\:/, ":");
+
+                this.model.set('_media', media); 
+            }
+
             this.checkIfResetOnRevisit();
         },
 

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -45,7 +45,7 @@ define(function(require) {
                 // This prevents conflicts with HTTP/HTTPS
                 var media = this.model.get('_media');
 
-                media.source = media.source.replace(/^https?\:/, ":");
+                media.source = media.source.replace(/^https?\:/, "");
 
                 this.model.set('_media', media); 
             }


### PR DESCRIPTION
YouTube and Vimeo give share links with HTTPS, by removing the protocol from the URL it prevents any problems with the protocol not matching the server on which the Adapt content is hosted.