### PR TITLE
issue-1213: resize window when video height changes 

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -123,6 +123,28 @@ define(function(require) {
             } else {
                 this.$('.component-widget').on('inview', _.bind(this.inview, this));
             }
+
+            try {
+                var observer = new MutationObserver(function(mutations) {
+                    mutations.forEach(function(mutation) {
+                        $(window).resize();
+                        observer.disconnect();
+                    });
+                });
+                observer.observe(this.mediaElement, {
+                    attributes: true,
+                    attributeFilter: ["height"]
+                });
+            } catch (error) {
+                // Fall back for older browsers
+                this.mediaElement.addEventListener('loadeddata', this.mediaLoadedData());
+            }
+        },
+
+        mediaLoadedData: function() {
+            setTimeout(function() {
+                $(window).resize();
+            }, 300);
         },
 
         // Overrides the default play/pause functionality to stop accidental playing on touch devices

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -137,7 +137,12 @@ define(function(require) {
                 });
             } catch (error) {
                 // Fall back for older browsers
-                this.mediaElement.addEventListener('loadeddata', this.mediaLoadedData());
+                if (document.addEventListener) {
+                    this.mediaElement.addEventListener('loadeddata', this.mediaLoadedData());
+                } else {
+                    // IE8
+                    this.mediaElement.attachEvent('loadeddata', this.mediaLoadedData());
+                }
             }
         },
 


### PR DESCRIPTION
[adaptlearning/adapt_framework#1213](https://github.com/adaptlearning/adapt_framework/issues/1213)

This fixes an issue we were having using trickle with the media component.  Would value any feedback or better/simpler ways of doing this.  We've tested in the following browsers:
- IE9
- IE11
- Edge
- Chrome (52)
- Firefox (32)
