### PR TITLE
Controlled media scrub

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ guide the learner’s interaction with the component.
 
 **_playsinline** (boolean): If set to `true`, videos will play 'inline' on iPhones (the same way they do on iPads). Note that this feature is only available in iOS10 and above. The default is `false`.    
 
-**_preventForwardScrubbing** (boolean): If enabled, will attempt to prevent users from skipping ahead in media (audio/video) unless '_isComplete' is marked as 'true'.  Users can skip backwards, and back up to the maxViewed time tracked by updateTime.
+**_preventForwardScrubbing** (boolean): If enabled, will attempt to prevent users from skipping ahead in media (audio/video) unless '_isComplete' is marked as 'true'.  Users can skip backwards, and back up to the maxViewed time tracked by updateTime. Note: This does not apply to full screen iOS users and IE users may be able to circumvent this rule by using video play speed options in browser.  
 
 **_startLanguage** (string): If using closed captions with multiple languages, use this property to specify which language should be shown by default. The value of this property must match one of the **srclang** values.  
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ guide the learner’s interaction with the component.
 
 **_allowFullScreen** (boolean): Determines whether fullscreen mode is available or not. Note that changing this setting has no effect in Internet Explorer 9 as this browser does not support fullscreen mode for HTML video.
 
-**_playsinline** (boolean): If set to `true`, videos will play 'inline' on iPhones (the same way they do on iPads). Note that this feature is only available in iOS10 and above. The default is `false`.        
+**_playsinline** (boolean): If set to `true`, videos will play 'inline' on iPhones (the same way they do on iPads). Note that this feature is only available in iOS10 and above. The default is `false`.    
+
+**_preventForwardScrubbing** (boolean): If set to 'true', users will not be able to scrub ahead in media (audio/video) unless '_isComplete' is marked as 'true'.  They can skip backwards, and back up to the maxViewed time tracked by updateTime.     
 
 **_startLanguage** (string): If using closed captions with multiple languages, use this property to specify which language should be shown by default. The value of this property must match one of the **srclang** values.  
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ guide the learner’s interaction with the component.
 
 **_playsinline** (boolean): If set to `true`, videos will play 'inline' on iPhones (the same way they do on iPads). Note that this feature is only available in iOS10 and above. The default is `false`.    
 
-**_preventForwardScrubbing** (boolean): If set to 'true', users will not be able to scrub ahead in media (audio/video) unless '_isComplete' is marked as 'true'.  They can skip backwards, and back up to the maxViewed time tracked by updateTime.     
+**_preventForwardScrubbing** (boolean): If enabled, will attempt to prevent users from skipping ahead in media (audio/video) unless '_isComplete' is marked as 'true'.  Users can skip backwards, and back up to the maxViewed time tracked by updateTime.
 
 **_startLanguage** (string): If using closed captions with multiple languages, use this property to specify which language should be shown by default. The value of this property must match one of the **srclang** values.  
 

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -318,9 +318,9 @@ define([
 
             if (this.mediaElement) {
                 $(this.mediaElement).off({
-                    'play': this.onMediaElementPlay,
-                    'pause': this.onMediaElementPause,
-                    'ended': this.onMediaElementEnded,
+                	'play': this.onMediaElementPlay,
+                	'pause': this.onMediaElementPause,
+                	'ended': this.onMediaElementEnded,
                     'seeking': this.onMediaElementSeeking,
                     'timeupdate': this.onMediaElementTimeUpdate
                 });

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -160,6 +160,14 @@ define([
                 this.$('.component-widget').on('inview', _.bind(this.inview, this));
             }
 
+            // wrapper to check if preventForwardScrubbing is turned on.
+            if ((this.model.get('_preventForwardScrubbing')) && (!this.model.get('_isComplete'))) {
+                $(this.mediaElement).on({
+                    'seeking': this.onMediaElementSeeking.bind(this),
+                    'timeupdate': this.onMediaElementTimeUpdate.bind(this)
+                });
+            }
+            
             // handle other completion events in the event Listeners 
             $(this.mediaElement).on({
             	'play': this.onMediaElementPlay,
@@ -190,6 +198,28 @@ define([
                 this.setCompletionStatus();
             }
         },
+        
+        onMediaElementSeeking: function(event) {
+            var maxViewed = this.model.get("_maxViewed");
+            if(!maxViewed){
+                maxViewed = 0;
+            }
+            if(event.target.currentTime > maxViewed){
+                event.target.currentTime = maxViewed;
+            }
+        },
+
+        onMediaElementTimeUpdate: function(event) {
+            var maxViewed = this.model.get("_maxViewed");
+            if(!maxViewed){
+                maxViewed = 0;
+            }
+            if(event.target.currentTime > maxViewed){
+                this.model.set("_maxViewed", event.target.currentTime);
+            }
+        },
+
+
 
         // Overrides the default play/pause functionality to stop accidental playing on touch devices
         setupPlayPauseToggle: function() {

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -40,7 +40,7 @@ define([
             this.listenTo(Adapt, 'device:changed', this.onDeviceChanged);
             this.listenTo(Adapt, 'accessibility:toggle', this.onAccessibilityToggle);
 
-            _.bindAll(this, 'onMediaElementPlay', 'onMediaElementPause', 'onMediaElementEnded');
+            _.bindAll(this, 'onMediaElementPlay', 'onMediaElementPause', 'onMediaElementEnded', 'onMediaElementTimeUpdate', 'onMediaElementSeeking');
 
             // set initial player state attributes
             this.model.set({
@@ -163,8 +163,8 @@ define([
             // wrapper to check if preventForwardScrubbing is turned on.
             if ((this.model.get('_preventForwardScrubbing')) && (!this.model.get('_isComplete'))) {
                 $(this.mediaElement).on({
-                    'seeking': this.onMediaElementSeeking.bind(this),
-                    'timeupdate': this.onMediaElementTimeUpdate.bind(this)
+                    'seeking': this.onMediaElementSeeking,
+                    'timeupdate': this.onMediaElementTimeUpdate
                 });
             }
             
@@ -201,25 +201,23 @@ define([
         
         onMediaElementSeeking: function(event) {
             var maxViewed = this.model.get("_maxViewed");
-            if(!maxViewed){
+            if(!maxViewed) {
                 maxViewed = 0;
             }
-            if(event.target.currentTime > maxViewed){
+            if (event.target.currentTime > maxViewed) {
                 event.target.currentTime = maxViewed;
             }
         },
 
         onMediaElementTimeUpdate: function(event) {
             var maxViewed = this.model.get("_maxViewed");
-            if(!maxViewed){
+            if (!maxViewed) {
                 maxViewed = 0;
             }
-            if(event.target.currentTime > maxViewed){
+            if (event.target.currentTime > maxViewed) {
                 this.model.set("_maxViewed", event.target.currentTime);
             }
         },
-
-
 
         // Overrides the default play/pause functionality to stop accidental playing on touch devices
         setupPlayPauseToggle: function() {
@@ -322,7 +320,9 @@ define([
                 $(this.mediaElement).off({
                 	'play': this.onMediaElementPlay,
                 	'pause': this.onMediaElementPause,
-                	'ended': this.onMediaElementEnded
+                	'ended': this.onMediaElementEnded,
+                    'seeking': this.onMediaElementSeeking,
+                    'timeupdate': this.onMediaElementTimeUpdate
                 });
 
                 this.mediaElement.src = "";

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -318,9 +318,9 @@ define([
 
             if (this.mediaElement) {
                 $(this.mediaElement).off({
-                	'play': this.onMediaElementPlay,
-                	'pause': this.onMediaElementPause,
-                	'ended': this.onMediaElementEnded,
+                    'play': this.onMediaElementPlay,
+                    'pause': this.onMediaElementPause,
+                    'ended': this.onMediaElementEnded,
                     'seeking': this.onMediaElementSeeking,
                     'timeupdate': this.onMediaElementTimeUpdate
                 });

--- a/properties.schema
+++ b/properties.schema
@@ -181,6 +181,15 @@
       "validators": [],
       "help": "If set to 'true', videos will play 'inline' on iPhones (the same way they do on iPads). Note that this feature is only available in iOS10 and above."
     },
+  "_preventForwardScrubbing": {
+      "type":"boolean",
+      "required":false,
+      "default": false,
+      "title": "Prevents user from skipping ahead in media.",
+      "inputType": {"type": "Boolean", "options": [true, false]},
+      "validators": [],
+      "help": "If set to true, will not allow users to skip beyond previously viewed points in media."
+    },
     "_transcript": {
       "type":"object",
       "required":false,

--- a/properties.schema
+++ b/properties.schema
@@ -202,7 +202,7 @@
           "title": "Trigger completion?",
           "inputType": {"type": "Boolean", "options": [true, false]},
           "validators": [],
-          "help": Set to 'true' to have this component mark as completed when the inline transcript is shown."
+          "help": "Set to 'true' to have this component mark as completed when the inline transcript is shown."
         },
         "_inlineTranscript": {
           "type":"boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -188,7 +188,7 @@
       "title": "Prevents user from skipping ahead in media.",
       "inputType": {"type": "Boolean", "options": [true, false]},
       "validators": [],
-      "help": "If set to true, will not allow users to skip beyond previously viewed points in media."
+      "help": "If enabled will attempt to prevent users from skipping ahead in audio/video."
     },
     "_transcript": {
       "type":"object",
@@ -202,7 +202,7 @@
           "title": "Trigger completion?",
           "inputType": "type": "Checkbox",
           "validators": [],
-          "help": "If enabled will attempt to prevent users from skipping ahead in audio/video."
+          "help": Set to 'true' to have this component mark as completed when the inline transcript is shown."
         },
         "_inlineTranscript": {
           "type":"boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -200,9 +200,9 @@
           "required":false,
           "default": true,
           "title": "Trigger completion?",
-          "inputType": {"type": "Boolean", "options": [true, false]},
+          "inputType": "type": "Checkbox",
           "validators": [],
-          "help": "Set to 'true' to have this component mark as completed when the inline transcript is shown."
+          "help": "If enabled will attempt to prevent users from skipping ahead in audio/video."
         },
         "_inlineTranscript": {
           "type":"boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -185,8 +185,8 @@
       "type":"boolean",
       "required":false,
       "default": false,
-      "title": "Prevents user from skipping ahead in media.",
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "title": "Attempt to prevent media scrubbing?",
+      "inputType": "Checkbox",
       "validators": [],
       "help": "If enabled will attempt to prevent users from skipping ahead in audio/video."
     },
@@ -200,7 +200,7 @@
           "required":false,
           "default": true,
           "title": "Trigger completion?",
-          "inputType": "type": "Checkbox",
+          "inputType": {"type": "Boolean", "options": [true, false]},
           "validators": [],
           "help": Set to 'true' to have this component mark as completed when the inline transcript is shown."
         },


### PR DESCRIPTION
The option '_preventForwardScrubbing' prevents users from skipping to the end of required media components in order to continue on to the next component. If the option '_preventForwardScrubbing' is set to 'true' this prevents users from scrubbing ahead any further than they have already viewed unless the user has completed the unit.  They can freely scrub backwards, and back up until the furthest viewed point.  While there are still possibilities for navigating around this, it removes the most obvious route for users to attempt to circumvent required learning materials. 