### PR TITLE
Issue/1410

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ guide the learner’s interaction with the component.
 
 **_showVolumeControl** (boolean): If enabled, the volume control will appear in the media player (Not supported on mobile devices)
 
-**_startVolume** (string): Defines the default volume (Not supported on mobile devices)
+**_startVolume** (string): Defines the default volume as a percentage (Not supported on mobile devices).  This can be set with or without the percentage sign in the string
 
 **_media** (object): The media attributes group will contain different values depending on the type of media: video or audio.
 For video it contains values for **mp4**, **webm**, **ogv**, **poster**, and **cc**. The properties **mp4**, **webm** and **ogv** are all optional, but at least one is required (see below for alternate properties for YouTube/Vimeo video).  

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ guide the learner’s interaction with the component.
 
 **_startLanguage** (string): If using closed captions with multiple languages, use this property to specify which language should be shown by default. The value of this property must match one of the **srclang** values.  
 
-**_media** (object): The media attributes group will contain different values depending on the type of media: video or audio.  
+**_showVolumeControl** (boolean): If enabled, the volume control will appear in the media player (Not supported in mobile devices)
+
+**_startVolume** (string): Defines the default volume (Not supported in mobile devices)
+
+**_media** (object): The media attributes group will contain different values depending on the type of media: video or audio.
 For video it contains values for **mp4**, **webm**, **ogv**, **poster**, and **cc**. The properties **mp4**, **webm** and **ogv** are all optional, but at least one is required (see below for alternate properties for YouTube/Vimeo video).  
 For audio it contains **mp3** and **ogg**. As with video, both are optional, but at least one is required.  
 The decision to include more than one file format is typically based on the browser/s used by the targeted audience. The mostly widely supported video file format is [mp4](http://caniuse.com/#feat=mpeg4) (specifically [H.264/MPEG-4 Part 10 AVC](https://en.wikipedia.org/wiki/H.264/MPEG-4_AVC)). The most widely supported audio format is mp3.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ guide the learner’s interaction with the component.
 
 **_startLanguage** (string): If using closed captions with multiple languages, use this property to specify which language should be shown by default. The value of this property must match one of the **srclang** values.  
 
-**_showVolumeControl** (boolean): If enabled, the volume control will appear in the media player (Not supported in mobile devices)
+**_showVolumeControl** (boolean): If enabled, the volume control will appear in the media player (Not supported on mobile devices)
 
-**_startVolume** (string): Defines the default volume (Not supported in mobile devices)
+**_startVolume** (string): Defines the default volume (Not supported on mobile devices)
 
 **_media** (object): The media attributes group will contain different values depending on the type of media: video or audio.
 For video it contains values for **mp4**, **webm**, **ogv**, **poster**, and **cc**. The properties **mp4**, **webm** and **ogv** are all optional, but at least one is required (see below for alternate properties for YouTube/Vimeo video).  

--- a/example.json
+++ b/example.json
@@ -13,7 +13,7 @@
     "_useClosedCaptions":true,
     "_startLanguage":"en",
     "_showVolumeControl":true,
-    "_startVolume":"40%",
+    "_startVolume":"80%",
     "_playsinline": false,
     "_media": {
         "mp4": "course/assets/big_buck_bunny.mp4",

--- a/example.json
+++ b/example.json
@@ -12,6 +12,8 @@
     "_setCompletionOn":"inview",
     "_useClosedCaptions":true,
     "_startLanguage":"en",
+    "_showVolumeControl":true,
+    "_startVolume":"40%",
     "_playsinline": false,
     "_media": {
         "mp4": "course/assets/big_buck_bunny.mp4",

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -6,9 +6,8 @@ define([
 ], function(Adapt, ComponentView) {
 
     var froogaloopAdded = false;
-    var isMobile = mejs.MediaFeatures.isiOS || mejs.MediaFeatures.isAndroid;
 
-    // The following function is used to to prevent a memory leak in Internet Explorer 
+    // The following function is used to to prevent a memory leak in Internet Explorer
     // See: http://javascript.crockford.com/memory/leak.html
     function purge(d) {
         var a = d.attributes, i, l, n;
@@ -367,19 +366,9 @@ define([
 
             this.addThirdPartyAfterFixes();
 
-            if (!isMobile) {
-                this.setInitialVolume();
-            }
-
             this.setReadyStatus();
             this.setupEventListeners();
         },
-
-         setInitialVolume: function() {
-             var volume = this.model.get('_startVolume') === undefined ? '30%' : this.model.get('_startVolume');
-
-             this.mediaElement.player.setVolume(parseInt(volume)/100); 
-         },
 
         addThirdPartyAfterFixes: function() {
             var media = this.model.get("_media");

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -87,6 +87,10 @@ define([
                 }
             }
 
+            if(this.model.has('_startVolume')) {
+                modelOptions.startVolume = parseInt(this.model.get('_startVolume'))/100;
+            }
+
             modelOptions.success = _.bind(this.onPlayerReady, this);
 
             if (this.model.get('_useClosedCaptions')) {

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -87,10 +87,6 @@ define([
                 }
             }
 
-            if(this.model.has('_startVolume')) {
-                modelOptions.startVolume = parseInt(this.model.get('_startVolume'))/100;
-            }
-
             modelOptions.success = _.bind(this.onPlayerReady, this);
 
             if (this.model.get('_useClosedCaptions')) {
@@ -369,6 +365,10 @@ define([
             }
 
             this.addThirdPartyAfterFixes();
+
+            if(this.model.has('_startVolume')) {
+                this.mediaElement.player.setVolume(parseInt(this.model.get('_startVolume'))/100);
+            }
 
             this.setReadyStatus();
             this.setupEventListeners();

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -367,6 +367,7 @@ define([
             this.addThirdPartyAfterFixes();
 
             if(this.model.has('_startVolume')) {
+                // Setting the start volume only works with the Flash-based player if you do it here rather than in setupPlayer
                 this.mediaElement.player.setVolume(parseInt(this.model.get('_startVolume'))/100);
             }
 

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -82,6 +82,9 @@ define([
                 if (this.model.get("_allowFullScreen") && !$("html").is(".ie9")) {
                     modelOptions.features.push('fullscreen');
                 }
+                if (this.model.get('_showVolumeControl')) {
+                    modelOptions.features.push('volume');
+                }
             }
 
             modelOptions.success = _.bind(this.onPlayerReady, this);

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -83,7 +83,7 @@ define([
                 if (this.model.get("_allowFullScreen") && !$("html").is(".ie9")) {
                     modelOptions.features.push('fullscreen');
                 }
-                if (!isMobile && this.model.get('_showVolumeControl')) {
+                if (this.model.get('_showVolumeControl')) {
                     modelOptions.features.push('volume');
                 }
             }

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -362,10 +362,17 @@ define([
             }
 
             this.addThirdPartyAfterFixes();
+            this.setInitialVolume();
 
             this.setReadyStatus();
             this.setupEventListeners();
         },
+
+         setInitialVolume: function() {
+             var volume = this.model.get('_startVolume') === undefined ? '30%' : this.model.get('_startVolume');
+
+             this.mediaElement.player.setVolume(parseInt(volume)/100); 
+         },
 
         addThirdPartyAfterFixes: function() {
             var media = this.model.get("_media");

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -6,7 +6,8 @@ define([
 ], function(Adapt, ComponentView) {
 
     var froogaloopAdded = false;
-    
+    var isMobile = mejs.MediaFeatures.isiOS || mejs.MediaFeatures.isAndroid;
+
     // The following function is used to to prevent a memory leak in Internet Explorer 
     // See: http://javascript.crockford.com/memory/leak.html
     function purge(d) {
@@ -82,7 +83,7 @@ define([
                 if (this.model.get("_allowFullScreen") && !$("html").is(".ie9")) {
                     modelOptions.features.push('fullscreen');
                 }
-                if (this.model.get('_showVolumeControl')) {
+                if (!isMobile && this.model.get('_showVolumeControl')) {
                     modelOptions.features.push('volume');
                 }
             }
@@ -365,7 +366,10 @@ define([
             }
 
             this.addThirdPartyAfterFixes();
-            this.setInitialVolume();
+
+            if (!isMobile) {
+                this.setInitialVolume();
+            }
 
             this.setReadyStatus();
             this.setupEventListeners();

--- a/properties.schema
+++ b/properties.schema
@@ -176,8 +176,8 @@
       "type":"string",
       "required":true,
       "enum": ["0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"],
-      "default": "30%",
-      "title": "Default volume (Not supported in mobile devices)",
+      "default": "80%",
+      "title": "Default volume (Not supported on mobile devices)",
       "inputType": {"type": "Select", "options":["0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"]},
       "validators": ["required"],
       "help": "Defines the default volume. On mobile devices the audio level is under the user's physical control"

--- a/properties.schema
+++ b/properties.schema
@@ -167,20 +167,20 @@
       "type":"boolean",
       "required":false,
       "default": false,
-      "title": "Show Volume Control",
+      "title": "Show Volume Control (Not supported in mobile devices)",
       "inputType": {"type": "Boolean", "options": [true, false]},
       "validators": [],
-      "help": "If set to 'true', the volume control will appear in the media player."
+      "help": "If set to 'true', the volume control will appear in the media player. On mobile devices the audio level is under the user's physical control."
     },
     "_startVolume": {
       "type":"string",
       "required":true,
       "enum": ["0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"],
       "default": "30%",
-      "title": "Default volume",
+      "title": "Default volume (Not supported in mobile devices)",
       "inputType": {"type": "Select", "options":["0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"]},
       "validators": ["required"],
-      "help": "Defines the default volume"
+      "help": "Defines the default volume. On mobile devices the audio level is under the user's physical control"
     },
     "_allowFullScreen": {
       "type":"boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -163,6 +163,16 @@
       "validators": [],
       "help": "Select which closed caption language to display by default. Only required when closed captions are enabled and there are multiple languages."
     },
+    "_startVolume": {
+      "type":"string",
+      "required":true,
+      "enum": ["0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"],
+      "default": "30%",
+      "title": "Default volume",
+      "inputType": {"type": "Select", "options":["0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"]},
+      "validators": ["required"],
+      "help": "Defines the default volume"
+    },
     "_allowFullScreen": {
       "type":"boolean",
       "required":false,

--- a/properties.schema
+++ b/properties.schema
@@ -167,7 +167,7 @@
       "type":"boolean",
       "required":false,
       "default": false,
-      "title": "Show Volume Control (Not supported in mobile devices)",
+      "title": "Show Volume Control (Not supported on mobile devices)",
       "inputType": {"type": "Boolean", "options": [true, false]},
       "validators": [],
       "help": "If set to 'true', the volume control will appear in the media player. On mobile devices the audio level is under the user's physical control."

--- a/properties.schema
+++ b/properties.schema
@@ -163,6 +163,15 @@
       "validators": [],
       "help": "Select which closed caption language to display by default. Only required when closed captions are enabled and there are multiple languages."
     },
+    "_showVolumeControl": {
+      "type":"boolean",
+      "required":false,
+      "default": false,
+      "title": "Show Volume Control",
+      "inputType": {"type": "Boolean", "options": [true, false]},
+      "validators": [],
+      "help": "If set to 'true', the volume control will appear in the media player."
+    },
     "_startVolume": {
       "type":"string",
       "required":true,


### PR DESCRIPTION
This PR adds a "Show Volume Control" and "Default Volume" setting to the media component

On mobile devices these settings have no effect and we don't try to set them.  This is because Android and iOS audio levels are controlled by the devices themselves.

![screen shot 2017-06-08 at 12 18 56](https://user-images.githubusercontent.com/28761622/26926233-c904de7a-4c44-11e7-9d3f-afa5e58c2b5e.png)
