### PR TITLE
mejs-overlay hover state bug fix

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -80,6 +80,23 @@
         width:100%;
         display:block;
     }
+    
+    // Bug Fix for touch devices to override standard hover event in mep.less L119
+    // ==============================
+    .mejs-overlay {
+        &:hover {
+            .mejs-overlay-button {
+                background-position: 0 0;
+            }
+        }
+
+        .no-touch &:hover {
+            .mejs-overlay-button {
+                background-position: 0 -100px;
+            }
+        }
+    }
+    // ==============================
 
     .mejs-overlay-button {
         background-image: url(../../assets/bigplay.svg);


### PR DESCRIPTION
Override the default hover state for 'mejs-overlay' and tie it to Modernizr's 'no-touch' class to stop the hover state from appearing on touch devices.