### PR TITLE
Avoid use of relative protocol when loading remote media

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -53,13 +53,14 @@ define([
             });
 
             if (this.model.get('_media').source) {
-                // Remove the protocol for streaming service.
-                // This prevents conflicts with HTTP/HTTPS
                 var media = this.model.get('_media');
 
-                media.source = media.source.replace(/^https?\:/, "");
+                // Avoid loading of Mixed Content (insecure content on a secure page)
+                if (window.location.protocol === 'https:' && media.source.indexOf('http:') === 0) {
+                    media.source = media.source.replace(/^http\:/, 'https:');
+                }
 
-                this.model.set('_media', media); 
+                this.model.set('_media', media);
             }
 
             this.checkIfResetOnRevisit();


### PR DESCRIPTION
By forcing remote media to use a relative protocol, it causes the content to fail to load if it is running over a protocol other than `http:` or `https:` (e.g. `file:`). (Additionally, the use of relative protocols is considered an anti-pattern by some: https://www.paulirish.com/2010/the-protocol-relative-url/).

This only changes the source if the page is being loaded over a secure connection and the remote content is not; to avoid accidentally loading Mixed Content, it attempts to load the asset over https instead.