### PR TITLE
Changed Modernizr.load to $.getScript

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -156,17 +156,6 @@ define([
 		                    froogaloopAdded = false;
 		                    console.log('Could not load froogaloop.js');
 	                    });
-                    // Modernizr.load has been deprecated
-                    // https://modernizr.com/news/modernizr-3-new-release-site
-                    /*
-                    Modernizr.load({
-                        load: "assets/froogaloop.js",
-                        complete: function() {
-                            froogaloopAdded = true;
-                            callback();
-                        }
-                    });
-                    */
                     break;
                 default:
                     callback();

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -147,6 +147,18 @@ define([
                     modelOptions.hideVideoControlsOnLoad = true;
                     modelOptions.features = [];
                     if (froogaloopAdded) return callback();
+                    $.getScript("assets/froogaloop.js")
+                    	.done(function() {
+												froogaloopAdded = true;
+												callback();
+	                    })
+	                    .fail(function(){
+		                    froogaloopAdded = false;
+		                    console.log('Could not load froogaloop.js');
+	                    });
+                    // Modernizr.load has been deprecated
+                    // https://modernizr.com/news/modernizr-3-new-release-site
+                    /*
                     Modernizr.load({
                         load: "assets/froogaloop.js",
                         complete: function() {
@@ -154,6 +166,7 @@ define([
                             callback();
                         }
                     });
+                    */
                     break;
                 default:
                     callback();

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -148,14 +148,14 @@ define([
                     modelOptions.features = [];
                     if (froogaloopAdded) return callback();
                     $.getScript("assets/froogaloop.js")
-                    	.done(function() {
-												froogaloopAdded = true;
-												callback();
-	                    })
-	                    .fail(function(){
-		                    froogaloopAdded = false;
-		                    console.log('Could not load froogaloop.js');
-	                    });
+                        .done(function() {
+                            froogaloopAdded = true;
+                            callback();
+                        })
+                        .fail(function() {
+                            froogaloopAdded = false;
+                            console.log('Could not load froogaloop.js');
+                        });
                     break;
                 default:
                     callback();


### PR DESCRIPTION
Modernizr.load has been deprecated resulting on a error when using the media component to display a Vimeo video. Fixed by changing Modernizr.load for $.getScript.