### PR TITLE
Updated to only change the button text

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -399,20 +399,20 @@ define([
         onToggleInlineTranscript: function(event) {
             if (event) event.preventDefault();
             var $transcriptBodyContainer = this.$(".media-inline-transcript-body-container");
-            var $button = this.$(".media-inline-transcript-button");
+            var $buttonText = this.$(".media-inline-transcript-button .transcript-text-container");
 
             if ($transcriptBodyContainer.hasClass("inline-transcript-open")) {
                 $transcriptBodyContainer.stop(true,true).slideUp(function() {
                     $(window).resize();
                 });
                 $transcriptBodyContainer.removeClass("inline-transcript-open");
-                $button.html(this.model.get("_transcript").inlineTranscriptButton);
+                $buttonText.html(this.model.get("_transcript").inlineTranscriptButton);
             } else {
                 $transcriptBodyContainer.stop(true,true).slideDown(function() {
                     $(window).resize();
                 }).a11y_focus();
                 $transcriptBodyContainer.addClass("inline-transcript-open");
-                $button.html(this.model.get("_transcript").inlineTranscriptCloseButton);
+                $buttonText.html(this.model.get("_transcript").inlineTranscriptCloseButton);
 
                 if (this.model.get('_transcript')._setCompletionOnView !== false) {
                     this.setCompletionStatus();

--- a/templates/media.hbs
+++ b/templates/media.hbs
@@ -36,7 +36,7 @@
 
       <div class="media-transcript-button-container">
         {{#if _transcript._inlineTranscript}}
-          <button class="media-inline-transcript-button button" role="button">
+          <button class="media-inline-transcript-button button">
             <div class="transcript-text-container">
               {{#if _transcript.inlineTranscriptButton}}
                 {{_transcript.inlineTranscriptButton}}
@@ -47,7 +47,7 @@
           </button>
         {{/if}}
         {{#if _transcript._externalTranscript}}
-          <button onclick="window.open('{{_transcript.transcriptLink}}')" class="media-external-transcript-button button" role="button">
+          <button onclick="window.open('{{_transcript.transcriptLink}}')" class="media-external-transcript-button button">
             <div class="transcript-text-container">
               {{#if _transcript.transcriptLinkButton}}
                 {{_transcript.transcriptLinkButton}}


### PR DESCRIPTION
The Media component currently changes the DOM structure when the transcript button is opened or closed. This change makes the `transcript-text-container` be updated instead which keeps the DOM structure the same.

resolves https://github.com/adaptlearning/adapt_framework/issues/2062