### PR TITLE
have media component remember learner's choice of captions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-media",
   "version": "3.0.2",
-  "framework": ">=3",
+  "framework": ">=3.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-media",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
   "displayName": "Media",

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -32,9 +32,9 @@ define([
      * Default shortcut keys trap a screen reader user inside the player once in focus. These keys are unnecessary
      * as one may traverse the player in a linear fashion without needing to know or use shortcut keys. Below is
      * the removal of the default shortcut keys.
-     * 
-     * The default seek interval functions are passed two different data types from mejs which they handle incorrectly. One 
-     * is a duration integer the other is the player object. The default functions error on slider key press and so break 
+     *
+     * The default seek interval functions are passed two different data types from mejs which they handle incorrectly. One
+     * is a duration integer the other is the player object. The default functions error on slider key press and so break
      * accessibility. Below is a correction.
      */
     _.extend(mejs.MepDefaults, {
@@ -55,6 +55,15 @@ define([
             "click .media-inline-transcript-button": "onToggleInlineTranscript",
             "click .media-external-transcript-button": "onExternalTranscriptClicked",
             "click .js-skip-to-transcript": "onSkipToTranscript"
+        },
+
+        className: function() {
+            var classes = ComponentView.prototype.className.call(this);
+            var playerOptions = this.model.get('_playerOptions');
+            if (playerOptions && playerOptions.toggleCaptionsButtonWhenOnlyOne) {
+                classes += " toggle-captions";
+            }
+            return classes;
         },
 
         preRender: function() {
@@ -110,7 +119,10 @@ define([
             }
 
             /*
-                Unless we are on Android/iOS and using native controls, when MediaElementJS initializes the player it will invoke the success callback prior to performing one last call to setPlayerSize. This call to setPlayerSize is deferred by 50ms so we add a delay of 100ms here to ensure that we don't invoke setReadyStatus until the player is definitely finished rendering.
+            Unless we are on Android/iOS and using native controls, when MediaElementJS initializes the player
+            it will invoke the success callback prior to performing one last call to setPlayerSize.
+            This call to setPlayerSize is deferred by 50ms so we add a delay of 100ms here to ensure that
+            we don't invoke setReadyStatus until the player is definitely finished rendering.
             */
 
             modelOptions.success = _.debounce(this.onPlayerReady.bind(this), 100);

--- a/less/media.less
+++ b/less/media.less
@@ -153,6 +153,14 @@
         -webkit-clip-path: polygon(0px 0px, 0px 0px,0px 0px, 0px 0px); // required for Safari/Chrome iOS 11. Ref: https://caniuse.com/#feat=css-clip-path
     }
     // ==============================
+
+    // Bug fix for CC button language selector still appearing when toggleCaptionsButtonWhenOnlyOne: true
+    // see https://github.com/adaptlearning/adapt_framework/issues/1883
+    // ==============================
+    &.toggle-captions .mejs-captions-selector {
+        display: none !important;
+    }
+    // ==============================
 }
 
 

--- a/templates/media.hbs
+++ b/templates/media.hbs
@@ -28,7 +28,7 @@
           {{/if}}
           {{#if _useClosedCaptions}}
               {{#each _media.cc}}
-                  <track kind="subtitles" src="{{src}}" type="text/vtt" srclang="{{srclang}}" />
+                <track kind="subtitles" src="{{src}}" type="text/vtt" srclang="{{srclang}}" />
               {{/each}}
           {{/if}}
         </video>


### PR DESCRIPTION
see https://github.com/adaptlearning/adapt_framework/issues/2284

Well, this took a lot longer than I thought as I'd completely forgotten that the media component supports multiple caption languages!

On the off chance that media component 'a' has a captions language that's not present in media component 'b' - and the user selects that language, 'b' will default to whatever language is set in `_startLanguage`. If that's not set, it will simply turn its own captions off. The actual language the user chose will be the one stored in `offlineStorage`.

also fixes https://github.com/adaptlearning/adapt_framework/issues/1883 - would be interested to get some comments on how I have implemented this (using `className` function in adapt-contrib-media.js) - the alternative would be to do this:
![toggle-captions-media-hbs](https://user-images.githubusercontent.com/1249597/49304308-df7b4d00-f4c3-11e8-990a-2b65aca1212e.png)
which is less code - but it does seem that a lot of themes still have copies of the core templates, so those wouldn't pick up this change. Happy to switch if people think doing it via media.hbs is better.