### PR TITLE
#2128 trigger pause when media component leaves view

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ guide the learner’s interaction with the component.
 
 **_allowFullScreen** (boolean): Determines whether fullscreen mode is available or not. Note that changing this setting has no effect in Internet Explorer 9 as this browser does not support fullscreen mode for HTML video.
 
-**_pauseWhenNotInview**  (boolean): If set to true, pause playback when video is no longer in view. The default is `false`.
+**_pauseWhenOffScreen**  (boolean): If set to true, pause playback when video is no longer in view. The default is `false`.
 
 **_playsinline** (boolean): If set to `true`, videos will play 'inline' on iPhones (the same way they do on iPads). Note that this feature is only available in iOS10 and above. The default is `false`.    
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ guide the learner’s interaction with the component.
 
 **_allowFullScreen** (boolean): Determines whether fullscreen mode is available or not. Note that changing this setting has no effect in Internet Explorer 9 as this browser does not support fullscreen mode for HTML video.
 
+**_pauseWhenNotInview**  (boolean): If set to true, pause playback when video is no longer in view. The default is `false`.
+
 **_playsinline** (boolean): If set to `true`, videos will play 'inline' on iPhones (the same way they do on iPads). Note that this feature is only available in iOS10 and above. The default is `false`.    
 
 **_preventForwardScrubbing** (boolean): If enabled, will attempt to prevent users from skipping ahead in media (audio/video) unless '_isComplete' is marked as 'true'.  Users can skip backwards, and back up to the maxViewed time tracked by updateTime. Note: This does not apply to full screen iOS users and IE users may be able to circumvent this rule by using video play speed options in browser.  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-media",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "framework": ">=3.3",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-media",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-media",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "framework": ">=3.3",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-media",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/example.json
+++ b/example.json
@@ -13,7 +13,7 @@
     "_useClosedCaptions": true,
     "_startLanguage": "en",
     "_allowFullScreen": true,
-    "_pauseWhenNotInview": false,
+    "_pauseWhenOffScreen": false,
     "_showVolumeControl": true,
     "_startVolume": "80%",
     "_playsinline": false,

--- a/example.json
+++ b/example.json
@@ -13,6 +13,7 @@
     "_useClosedCaptions": true,
     "_startLanguage": "en",
     "_allowFullScreen": true,
+    "_pauseWhenNotInview": false,
     "_showVolumeControl": true,
     "_startVolume": "80%",
     "_playsinline": false,

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -222,9 +222,6 @@ define([
                 'ended': this.onMediaElementEnded
             });
 
-            var pauseWhenNotInview = this.model.get('_pauseWhenNotInview');
-            if (pauseWhenNotInview) $(this.mediaElement).on('inview', this.onMediaElementInview);
-
             // occasionally the mejs code triggers a click of the captions language
             // selector during setup, this slight delay ensures we skip that
             _.delay(this.listenForCaptionsChange.bind(this), 250);
@@ -289,6 +286,9 @@ define([
 
             Adapt.trigger("media:stop", this);
 
+            var pauseWhenOffScreen = this.model.get('_pauseWhenOffScreen');
+            if (pauseWhenOffScreen) $(this.mediaElement).on('inview', this.onMediaElementInview);
+
             this.model.set({
                 '_isMediaPlaying': true,
                 '_isMediaEnded': false
@@ -301,6 +301,8 @@ define([
 
         onMediaElementPause: function(event) {
             this.queueGlobalEvent('pause');
+
+            $(this.mediaElement).off('inview', this.onMediaElementInview);
 
             this.model.set('_isMediaPlaying', false);
         },

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -286,8 +286,7 @@ define([
 
             Adapt.trigger("media:stop", this);
 
-            var pauseWhenOffScreen = this.model.get('_pauseWhenOffScreen');
-            if (pauseWhenOffScreen) $(this.mediaElement).on('inview', this.onMediaElementInview);
+            if (this.model.get('_pauseWhenOffScreen')) $(this.mediaElement).on('inview', this.onMediaElementInview);
 
             this.model.set({
                 '_isMediaPlaying': true,

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -217,8 +217,8 @@ define([
 
             // handle other completion events in the event Listeners
             $(this.mediaElement).on({
-            	'play': this.onMediaElementPlay,
-            	'pause': this.onMediaElementPause,
+                'play': this.onMediaElementPlay,
+                'pause': this.onMediaElementPause,
                 'ended': this.onMediaElementEnded
             });
 
@@ -318,8 +318,7 @@ define([
         },
 
         onMediaElementInview: function(event, isInView) {
-            if (isInView || event.currentTarget.paused) return;
-            event.currentTarget.pause();
+            if (!isInView && !event.currentTarget.paused) event.currentTarget.pause();
         },
 
         onMediaElementSeeking: function(event) {

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -219,7 +219,8 @@ define([
             $(this.mediaElement).on({
             	'play': this.onMediaElementPlay,
             	'pause': this.onMediaElementPause,
-            	'ended': this.onMediaElementEnded
+                'ended': this.onMediaElementEnded,
+                'inview': this.onMediaElementInview
             });
 
             // occasionally the mejs code triggers a click of the captions language
@@ -310,6 +311,11 @@ define([
             if (this.completionEvent === 'ended') {
                 this.setCompletionStatus();
             }
+        },
+
+        onMediaElementInview: function(event, isInView) {
+            if (isInView || event.currentTarget.paused) return;
+            event.currentTarget.pause();
         },
 
         onMediaElementSeeking: function(event) {
@@ -428,7 +434,8 @@ define([
                     'pause': this.onMediaElementPause,
                     'ended': this.onMediaElementEnded,
                     'seeking': this.onMediaElementSeeking,
-                    'timeupdate': this.onMediaElementTimeUpdate
+                    'timeupdate': this.onMediaElementTimeUpdate,
+                    'inview': this.onMediaElementInview
                 });
 
                 this.mediaElement.src = "";

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -219,9 +219,11 @@ define([
             $(this.mediaElement).on({
             	'play': this.onMediaElementPlay,
             	'pause': this.onMediaElementPause,
-                'ended': this.onMediaElementEnded,
-                'inview': this.onMediaElementInview
+                'ended': this.onMediaElementEnded
             });
+
+            var pauseWhenNotInview = this.model.get('_pauseWhenNotInview');
+            if (pauseWhenNotInview) $(this.mediaElement).on('inview', this.onMediaElementInview);
 
             // occasionally the mejs code triggers a click of the captions language
             // selector during setup, this slight delay ensures we skip that

--- a/properties.schema
+++ b/properties.schema
@@ -190,7 +190,7 @@
       "inputType": "Checkbox",
       "validators": []
     },
-    "_pauseWhenNotInview": {
+    "_pauseWhenOffScreen": {
       "type": "boolean",
       "required": false,
       "default": false,

--- a/properties.schema
+++ b/properties.schema
@@ -190,6 +190,14 @@
       "inputType": "Checkbox",
       "validators": []
     },
+    "_pauseWhenNotInview": {
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "title": "Pause playback when video is no longer in view.",
+      "inputType": "Checkbox",
+      "validators": []
+    },
     "_playsinline": {
       "type": "boolean",
       "required": false,


### PR DESCRIPTION
In response to [#2128](https://github.com/adaptlearning/adapt_framework/issues/2128).

As per [this comment](https://github.com/adaptlearning/adapt_framework/issues/2128#issuecomment-396867757) media component is paused directly, rather than triggering `media:stop`.