### PR TITLE
remove skip to transcript button from tab order

### DIFF
--- a/templates/media.hbs
+++ b/templates/media.hbs
@@ -2,7 +2,7 @@
 <div class="media-inner component-inner">
     {{> component this}}
     {{#any _transcript._externalTranscript _transcript._inlineTranscript}}
-        <button class="aria-label js-skip-to-transcript" aria-label="{{_globals._components._media.skipToTranscript}}"></button>
+        <button class="aria-label js-skip-to-transcript" tabindex="-1" aria-label="{{_globals._components._media.skipToTranscript}}"></button>
     {{/any}}
     <div class="media-widget component-widget a11y-ignore-aria">
     {{#if _media.mp3}}


### PR DESCRIPTION
so that it's only available to screen reader users

fixes https://github.com/adaptlearning/adapt_framework/issues/2419