### PR TITLE
Ensure aria-valuemax is set to a valid value

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -467,6 +467,7 @@ define([
             }
 
             this.addThirdPartyAfterFixes();
+            this.cleanUpPlayerAfter();
 
             if(this.model.has('_startVolume')) {
                 // Setting the start volume only works with the Flash-based player if you do it here rather than in setupPlayer
@@ -483,6 +484,10 @@ define([
             case "video/vimeo":
                 this.$(".mejs-container").attr("tabindex", 0);
             }
+        },
+        
+        cleanUpPlayerAfter: function() {
+            this.$("[aria-valuemax='NaN']").attr("aria-valuemax", 0);
         },
 
         onScreenSizeChanged: function() {


### PR DESCRIPTION
fixes [#2431](https://github.com/adaptlearning/adapt_framework/issues/2431)

aria-valuemax="NaN" causes an error in a Lighthouse accessibility audit, this fixes by replacing with 0 post-render.