### PR TITLE
drop use of deprecated helper if_value_equals

### DIFF
--- a/templates/media.hbs
+++ b/templates/media.hbs
@@ -18,7 +18,7 @@
     {{#if _media.ogg}}
       <audio src="{{_media.ogg}}" type="audio/ogg" style="width: 100%; height: 100%;"/>
     {{else}}
-      <video aria-hidden="true" preload="none" width="640" height="360" {{#if _playsinline}}playsinline{{/if}} {{#if_value_equals _media.type "video/vimeo"}}{{else}}poster="{{_media.poster}}"{{/if_value_equals}} style="width:100%; height:100%;" controls="controls">
+      <video aria-hidden="true" preload="none" width="640" height="360" {{#if _playsinline}}playsinline{{/if}} {{#equals _media.type "video/vimeo"}}{{else}}poster="{{_media.poster}}"{{/equals}} style="width:100%; height:100%;" controls="controls">
         {{#if _media.source}}
           <source src="{{_media.source}}" type="{{_media.type}}"/>
         {{else}}


### PR DESCRIPTION
the `if_value_equals` helper is deprecated (since FW v4.4.0)