### PR TITLE
Fix Microsoft edge bug

### DIFF
--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -353,7 +353,7 @@ define([
           maxViewed = 0;
         }
         if (event.target.currentTime > maxViewed) {
-          if (!!maxViewedLastUpdate && event.target.currentTime - maxViewed > 1.1 * (maxViewedNow - maxViewedLastUpdate) / 1000) {
+          if (!!maxViewedLastUpdate && event.target.currentTime - maxViewed > (maxViewedNow - maxViewedLastUpdate) / 1000) {
             return;
           }
           this.model.set("_maxViewed", event.target.currentTime);

--- a/js/adapt-contrib-media.js
+++ b/js/adapt-contrib-media.js
@@ -347,11 +347,17 @@ define([
 
       onMediaElementTimeUpdate: function(event) {
         var maxViewed = this.model.get("_maxViewed");
+        var maxViewedLastUpdate = this.model.get("_maxViewedLastUpdate");
+        var maxViewedNow = new Date().getTime();
         if (!maxViewed) {
           maxViewed = 0;
         }
         if (event.target.currentTime > maxViewed) {
+          if (!!maxViewedLastUpdate && event.target.currentTime - maxViewed > 1.1 * (maxViewedNow - maxViewedLastUpdate) / 1000) {
+            return;
+          }
           this.model.set("_maxViewed", event.target.currentTime);
+          this.model.set("_maxViewedLastUpdate", maxViewedNow);
         }
       },
 


### PR DESCRIPTION
Option "Attempt to prevent media scrubbing?" doesn't work on Microsoft Edge.
**Description in details**
With this this option enabled, if I seek on Microsoft Edge the variable event.target.currentTime is update immediatly (skipping the controls in onMediaElementSeeking) and _maxViewed is always updated. 
**Solution**
To prevent this behaviour I check that _maxViewed is updated only with natural video play, not with seeking