### PR TITLE
Add aria hidden attribute to overlay play btn

### DIFF
--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -217,6 +217,7 @@ define([
       this.$('.media__widget').children('.mejs-offscreen').remove();
       this.$('[role=application]').removeAttr('role tabindex');
       this.$('[aria-controls]').removeAttr('aria-controls');
+      this.$('.mejs-overlay-play').attr('aria-hidden', 'true');
     }
 
     setupEventListeners() {


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt_framework/issues/3137

* Added aria hidden attribute to media overlay play btn to remove it from the tab order