### PR TITLE
issue/231 - Add region role to video container

### DIFF
--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -252,7 +252,10 @@ class MediaView extends ComponentView {
     this.$('.media__widget').children('.mejs-offscreen').remove();
     this.$('[role=application]').removeAttr('role tabindex');
     this.$('.mejs-container').attr('role', 'region');
-    this.$('.mejs-container').attr('aria-label', containerLabel);
+    this.$('.mejs-container').attr({
+      role: 'region',
+      'aria-label': containerLabel
+    });
     this.$('[aria-controls]').removeAttr('aria-controls');
     this.$('.mejs-overlay-play').attr('aria-hidden', 'true');
   }

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -248,9 +248,11 @@ class MediaView extends ComponentView {
   }
 
   cleanUpPlayer() {
+    const containerLabel = this.model.get('displayTitle') ? this.model.get('displayTitle') : this.model.get('title');
     this.$('.media__widget').children('.mejs-offscreen').remove();
     this.$('[role=application]').removeAttr('role tabindex');
     this.$('.mejs-container').attr('role', 'region');
+    this.$('.mejs-container').attr('aria-label', containerLabel);
     this.$('[aria-controls]').removeAttr('aria-controls');
     this.$('.mejs-overlay-play').attr('aria-hidden', 'true');
   }

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -251,7 +251,6 @@ class MediaView extends ComponentView {
     const containerLabel = this.model.get('displayTitle') || this.model.get('title');
     this.$('.media__widget').children('.mejs-offscreen').remove();
     this.$('[role=application]').removeAttr('role tabindex');
-    this.$('.mejs-container').attr('role', 'region');
     this.$('.mejs-container').attr({
       role: 'region',
       'aria-label': containerLabel

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -250,6 +250,7 @@ class MediaView extends ComponentView {
   cleanUpPlayer() {
     this.$('.media__widget').children('.mejs-offscreen').remove();
     this.$('[role=application]').removeAttr('role tabindex');
+    this.$('.mejs-container').attr('role', 'region');
     this.$('[aria-controls]').removeAttr('aria-controls');
     this.$('.mejs-overlay-play').attr('aria-hidden', 'true');
   }

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -248,7 +248,7 @@ class MediaView extends ComponentView {
   }
 
   cleanUpPlayer() {
-    const containerLabel = this.model.get('displayTitle') ? this.model.get('displayTitle') : this.model.get('title');
+    const containerLabel = this.model.get('displayTitle') || this.model.get('title');
     this.$('.media__widget').children('.mejs-offscreen').remove();
     this.$('[role=application]').removeAttr('role tabindex');
     this.$('.mejs-container').attr('role', 'region');


### PR DESCRIPTION
#231 Assigns the media container a role of 'region' instead of 'application'. Also uses the title and displayTitle as a label for aria context when learners focus on the media container.