### PR TITLE
Fix: contain fullscreen video when in portrait mode (fixes #248)

### DIFF
--- a/less/mep-overrides.less
+++ b/less/mep-overrides.less
@@ -72,14 +72,8 @@
 
 // Bug fix for when video aspect ratio is different to viewport
 // --------------------------------------------------
-// as video is set to object-fit: fill, horizontally center the video 
-.mejs-mediaelement {
-  left: 50%;
-  transform: translateX(-50%);
-}
-// allow the height to fill the viewport without distorting the video width
 .orientation-portrait .mejs-container-fullscreen video {
-  width: auto !important;
+  object-fit: contain;
 }
 
 // Bug fix for missing control icons on iOS touch devices

--- a/less/mep-overrides.less
+++ b/less/mep-overrides.less
@@ -70,7 +70,7 @@
   background-color: black;
 }
 
-// Bug fix for when video aspect ratio is different to viewport
+// Bug fix to contain video when in portrait mode
 // --------------------------------------------------
 .orientation-portrait .mejs-container-fullscreen video {
   object-fit: contain;

--- a/less/mep-overrides.less
+++ b/less/mep-overrides.less
@@ -70,6 +70,18 @@
   background-color: black;
 }
 
+// Bug fix for when video aspect ratio is different to viewport
+// --------------------------------------------------
+// as video is set to object-fit: fill, horizontally center the video 
+.mejs-mediaelement {
+  left: 50%;
+  transform: translateX(-50%);
+}
+// allow the height to fill the viewport without distorting the video width
+.orientation-portrait .mejs-container-fullscreen video {
+  width: auto !important;
+}
+
 // Bug fix for missing control icons on iOS touch devices
 // required for Safari/Chrome iOS 11. Ref: https://caniuse.com/#feat=css-clip-path
 // --------------------------------------------------


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-media/issues/248 

When a video is run fullscreen on an Android device, in portrait orientation, the aspect ratio of the video is incorrect as it is stretched to fill the viewport and distorts the video. 

This doesn't occur if using native Android controls via `_playerOptions.AndroidUseNativeControls: true`. The issue is restricted to Android only as iOS switches to native controls automatically when run fullscreen.