### PR TITLE
Fix: Chrome automatically exits full screen video if zoom is not 100% (fixes #255)

### DIFF
--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -79,7 +79,7 @@ window.mejs.MediaElementPlayer.prototype.setTrack = function (lang) {
 };
 
 /**
- * Overwrite mediaelement-and-player enterFullScreen to remove Chrome <17 bug fix
+ * Overwrite mediaelement-and-player enterFullScreen to remove Chrome <17 bug fix (Media issue #255)
 */
 
 window.mejs.MediaElementPlayer.prototype.enterFullScreen = function () {

--- a/libraries/mediaelement-and-player.js
+++ b/libraries/mediaelement-and-player.js
@@ -4570,30 +4570,30 @@ if (typeof jQuery != 'undefined') {
 				mejs.MediaFeatures.requestFullScreen(t.container[0]);
 				//return;
 
-				// if (t.isInIframe) {
-				// 	// sometimes exiting from fullscreen doesn't work
-				// 	// notably in Chrome <iframe>. Fixed in version 17
-				// 	setTimeout(function checkFullscreen() {
+				if (t.isInIframe) {
+					// sometimes exiting from fullscreen doesn't work
+					// notably in Chrome <iframe>. Fixed in version 17
+					setTimeout(function checkFullscreen() {
 
-				// 		if (t.isNativeFullScreen) {
-				// 			var percentErrorMargin = 0.002, // 0.2%
-				// 				windowWidth = $(window).width(),
-				// 				screenWidth = screen.width,
-				// 				absDiff = Math.abs(screenWidth - windowWidth),
-				// 				marginError = screenWidth * percentErrorMargin;
+						if (t.isNativeFullScreen) {
+							var percentErrorMargin = 0.002, // 0.2%
+								windowWidth = $(window).width(),
+								screenWidth = screen.width,
+								absDiff = Math.abs(screenWidth - windowWidth),
+								marginError = screenWidth * percentErrorMargin;
 
-				// 			// check if the video is suddenly not really fullscreen
-				// 			if (absDiff > marginError) {
-				// 				// manually exit
-				// 				t.exitFullScreen();
-				// 			} else {
-				// 				// test again
-				// 				setTimeout(checkFullscreen, 500);
-				// 			}
-				// 		}
+							// check if the video is suddenly not really fullscreen
+							if (absDiff > marginError) {
+								// manually exit
+								t.exitFullScreen();
+							} else {
+								// test again
+								setTimeout(checkFullscreen, 500);
+							}
+						}
 
-				// 	}, 1000);
-				// }
+					}, 1000);
+				}
 
 			} else if (t.fullscreeMode == 'fullwindow') {
 				// move into position

--- a/libraries/mediaelement-and-player.js
+++ b/libraries/mediaelement-and-player.js
@@ -4570,30 +4570,30 @@ if (typeof jQuery != 'undefined') {
 				mejs.MediaFeatures.requestFullScreen(t.container[0]);
 				//return;
 
-				if (t.isInIframe) {
-					// sometimes exiting from fullscreen doesn't work
-					// notably in Chrome <iframe>. Fixed in version 17
-					setTimeout(function checkFullscreen() {
+				// if (t.isInIframe) {
+				// 	// sometimes exiting from fullscreen doesn't work
+				// 	// notably in Chrome <iframe>. Fixed in version 17
+				// 	setTimeout(function checkFullscreen() {
 
-						if (t.isNativeFullScreen) {
-							var percentErrorMargin = 0.002, // 0.2%
-								windowWidth = $(window).width(),
-								screenWidth = screen.width,
-								absDiff = Math.abs(screenWidth - windowWidth),
-								marginError = screenWidth * percentErrorMargin;
+				// 		if (t.isNativeFullScreen) {
+				// 			var percentErrorMargin = 0.002, // 0.2%
+				// 				windowWidth = $(window).width(),
+				// 				screenWidth = screen.width,
+				// 				absDiff = Math.abs(screenWidth - windowWidth),
+				// 				marginError = screenWidth * percentErrorMargin;
 
-							// check if the video is suddenly not really fullscreen
-							if (absDiff > marginError) {
-								// manually exit
-								t.exitFullScreen();
-							} else {
-								// test again
-								setTimeout(checkFullscreen, 500);
-							}
-						}
+				// 			// check if the video is suddenly not really fullscreen
+				// 			if (absDiff > marginError) {
+				// 				// manually exit
+				// 				t.exitFullScreen();
+				// 			} else {
+				// 				// test again
+				// 				setTimeout(checkFullscreen, 500);
+				// 			}
+				// 		}
 
-					}, 1000);
-				}
+				// 	}, 1000);
+				// }
 
 			} else if (t.fullscreeMode == 'fullwindow') {
 				// move into position


### PR DESCRIPTION
Fixes #255 

### Fix
* Removes a fix for Chrome versions 16 and below. This was causing the initial issue with fullscreen video.

### Testing
See #255 