### PR TITLE
Fix: Make 'skip to transcript' button visible on focus (fixes #262)

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -11,6 +11,14 @@
     display: none;
   }
 
+  // Skip to transcript button
+  &__skip-to-transcript:not(:focus-visible) {
+    height: 0;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+  }
+
   // Cross browser bug fixes
   // --------------------------------------------------
   .me-plugin {

--- a/less/media.less
+++ b/less/media.less
@@ -12,11 +12,18 @@
   }
 
   // Skip to transcript button
-  &__skip-to-transcript:not(:focus-visible) {
-    height: 0;
-    padding: 0;
-    margin: 0;
-    overflow: hidden;
+  &__skip-to-transcript {
+
+    html:not(.has-accessibility) & {
+      .u-display-none;
+    }
+
+    &:not(:focus-visible) {
+      height: 0;
+      padding: 0;
+      margin: 0;
+      overflow: hidden;
+    }
   }
 
   // Cross browser bug fixes

--- a/templates/media.hbs
+++ b/templates/media.hbs
@@ -4,7 +4,9 @@
   {{> component this}}
 
   {{#any _transcript._externalTranscript _transcript._inlineTranscript}}
-  <button class="aria-label js-skip-to-transcript" tabindex="-1" aria-label="{{_globals._components._media.skipToTranscript}}"></button>
+  <button class="btn-text media__skip-to-transcript js-skip-to-transcript" tabindex="-1">
+    {{_globals._components._media.skipToTranscript}}
+  </button>
   {{/any}}
 
   <div class="component__widget media__widget">

--- a/templates/media.hbs
+++ b/templates/media.hbs
@@ -4,7 +4,7 @@
   {{> component this}}
 
   {{#any _transcript._externalTranscript _transcript._inlineTranscript}}
-  <button class="btn-text media__skip-to-transcript js-skip-to-transcript" tabindex="-1">
+  <button class="btn-text media__skip-to-transcript js-skip-to-transcript">
     {{_globals._components._media.skipToTranscript}}
   </button>
   {{/any}}


### PR DESCRIPTION
Fixes #262 

### Fix
* Makes the 'skip to transcript' button visible on keyboard focus.
