### PR TITLE
New: completion icon added to transcript button (fixes #290)

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -7,10 +7,6 @@
   
   // Transcript
   // --------------------------------------------------
-  &__transcript-body-inline {
-    display: none;
-  }
-
   // Skip to transcript button
   &__skip-to-transcript {
 
@@ -25,6 +21,26 @@
       overflow: hidden;
     }
   }
+
+  // Transcript container
+  &__transcript-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__transcript-btn-icon {
+    margin-inline-start: @icon-padding / 2;
+  }
+
+  &.is-complete &__transcript-btn-icon .icon {
+    .icon-tick;
+  }
+
+  &__transcript-body-inline {
+    display: none;
+  }
+
 
   // Cross browser bug fixes
   // --------------------------------------------------

--- a/templates/media.hbs
+++ b/templates/media.hbs
@@ -61,6 +61,9 @@
         {{_transcript.transcriptLink}}
         {{/if}}
       </span>
+      <span class="media__transcript-btn-icon">
+        <span class="icon" aria-hidden="true"></span>
+      </span>
     </button>
     {{/if}}
 
@@ -72,6 +75,9 @@
         {{else}}
         {{_transcript.transcriptLink}}
         {{/if}}
+      </span>
+      <span class="media__transcript-btn-icon">
+        <span class="icon" aria-hidden="true"></span>
       </span>
     </button>
     {{/if}}


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-media/issues/290

### New
* On completion, a checkmark icon is displayed on the transcript button

![media](https://github.com/adaptlearning/adapt-contrib-media/assets/7045330/827c2e8e-1971-41ed-b86e-df9c3a5f5996)


### Update
* Transcript button styled for consistency with `.nav__btn` text label/icon
* LESS styles structured in DOM order (skip to transcript btn, transcript btn, transcript body)

**Not included in PR**
Do you think we should display a plus icon for the inline transcript button to convey the button toggles/expands to reveal content? This would be consistent with the Accordion item button however I'm not wedded to this if people think it's unnecessary.  See example below.

![inline_transcript](https://github.com/adaptlearning/adapt-contrib-media/assets/7045330/242efae4-f306-4cd4-9818-5989774ee3ee)



