### PR TITLE
New: display plus icon for inline transcript button (fixes #292)

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -37,6 +37,10 @@
     .icon-tick;
   }
 
+  &__transcript-btn-inline .icon {
+    .icon-plus;
+  }
+
   &__transcript-body-inline {
     display: none;
   }


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-media/issues/292

### New
As per recent PR, [completion icon added to transcript button](https://github.com/adaptlearning/adapt-contrib-media/pull/291#event-12697477014), display a plus icon for the inline transcript button. 

This is consistent with other expand/collapse buttons such as Accordion.



