### PR TITLE
Fix: Call stripHtml function on the inline transcript content check [302]

### DIFF
--- a/test/e2e/media.cy.js
+++ b/test/e2e/media.cy.js
@@ -25,7 +25,7 @@ describe('Media', function () {
           cy.get('.media__transcript-body-inline').should('not.be.visible');
           cy.get('button.media__transcript-btn-inline').should('be.visible');
           cy.get('button.media__transcript-btn-inline').should('contain', mediaComponent._transcript.inlineTranscriptButton).click();
-          cy.get('.media__transcript-body-inline-inner').should('be.visible').should('contain', mediaComponent._transcript.inlineTranscriptBody);
+          cy.get('.media__transcript-body-inline-inner').should('be.visible').should('contain', stripHtml(mediaComponent._transcript.inlineTranscriptBody));
           cy.get('button.media__transcript-btn-inline').should('contain', mediaComponent._transcript.inlineTranscriptCloseButton).click();
           cy.get('.media__transcript-body-inline').should('not.be.visible');
         } else {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #302 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Call stripHtml function on the inline transcript content check