### PR TITLE
Fix: "Skip to transcript" button spacing (fixes #312)

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -9,12 +9,14 @@
   // --------------------------------------------------
   // Skip to transcript button
   &__skip-to-transcript {
+    margin-bottom: @item-margin;
 
     html:not(.has-accessibility) & {
       .u-display-none;
     }
 
     &:not(:focus-visible) {
+      display: block;
       height: 0;
       padding: 0;
       margin: 0;


### PR DESCRIPTION
Fix #312 

### Fix

1. Ensure "Skip to transcript" button does not take up space until in focus
2. Add bottom margin to button when visible

### Testing
1. Using keyboard navigation, tab until you come to a "Skip to transcript" button.