### PR TITLE
Fix: Preventing forward scrubbing (fixes: #319)

### DIFF
--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -192,20 +192,7 @@ class MediaView extends ComponentView {
       this.setupInviewCompletion('.component__widget');
     }
 
-    // wrapper to check if preventForwardScrubbing is turned on.
-    if ((this.model.get('_preventForwardScrubbing')) && (!this.model.get('_isComplete'))) {
-      $(this.mediaElement).on({
-        seeking: this.onMediaElementSeeking,
-        timeupdate: this.onMediaElementTimeUpdate
-      });
-
-      const timeSlider = this.$('.mejs__time-slider')[0];
-      if (timeSlider) {
-        timeSlider.style.pointerEvents = 'none';
-        timeSlider.addEventListener('input', (e) => e.preventDefault());
-        timeSlider.setAttribute('aria-disabled', 'true');
-      }
-    }
+    this.preventForwardScrubbing();
 
     // handle other completion events in the event Listeners
     $(this.mediaElement).on({
@@ -526,6 +513,25 @@ class MediaView extends ComponentView {
     }
     this.setCompletionStatus();
     Adapt.trigger('media:transcript', 'complete', this);
+  }
+
+  /**
+   * This function ensures that users cannot skip ahead in the media until they have watched it fully.
+   */
+  preventForwardScrubbing() {
+    if ((this.model.get('_preventForwardScrubbing')) && (!this.model.get('_isComplete'))) {
+      $(this.mediaElement).on({
+        seeking: this.onMediaElementSeeking,
+        timeupdate: this.onMediaElementTimeUpdate
+      });
+
+      const timeSlider = this.$('.mejs__time-slider')[0];
+      if (timeSlider) {
+        timeSlider.style.pointerEvents = 'none';
+        timeSlider.addEventListener('input', (e) => e.preventDefault());
+        timeSlider.setAttribute('aria-disabled', 'true');
+      }
+    }
   }
 
   /**

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -194,10 +194,12 @@ class MediaView extends ComponentView {
 
     // wrapper to check if preventForwardScrubbing is turned on.
     if ((this.model.get('_preventForwardScrubbing')) && (!this.model.get('_isComplete'))) {
-      $(this.mediaElement).on({
-        seeking: this.onMediaElementSeeking,
-        timeupdate: this.onMediaElementTimeUpdate
-      });
+      const timeSlider = this.$('.mejs__time-slider')[0];
+      if (timeSlider) {
+        timeSlider.style.pointerEvents = 'none';
+        timeSlider.addEventListener('input', (e) => e.preventDefault());
+        timeSlider.setAttribute('aria-disabled', 'true');
+      }
     }
 
     // handle other completion events in the event Listeners

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -194,6 +194,11 @@ class MediaView extends ComponentView {
 
     // wrapper to check if preventForwardScrubbing is turned on.
     if ((this.model.get('_preventForwardScrubbing')) && (!this.model.get('_isComplete'))) {
+      $(this.mediaElement).on({
+        seeking: this.onMediaElementSeeking,
+        timeupdate: this.onMediaElementTimeUpdate
+      });
+
       const timeSlider = this.$('.mejs__time-slider')[0];
       if (timeSlider) {
         timeSlider.style.pointerEvents = 'none';

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -525,11 +525,10 @@ class MediaView extends ComponentView {
       timeupdate: this.onMediaElementTimeUpdate
     });
     const timeSlider = this.$('.mejs__time-slider')[0];
-    if (timeSlider) {
-      timeSlider.style.pointerEvents = 'none';
-      timeSlider.addEventListener('input', (e) => e.preventDefault());
-      timeSlider.setAttribute('aria-disabled', 'true');
-    }
+    if (!timeSlider) return;
+    timeSlider.style.pointerEvents = 'none';
+    timeSlider.addEventListener('input', (e) => e.preventDefault());
+    timeSlider.setAttribute('aria-disabled', 'true');
   }
 
   /**

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -519,18 +519,16 @@ class MediaView extends ComponentView {
    * This function ensures that users cannot skip ahead in the media until they have watched it fully if `_preventForwardScrubbing` is enabled.
    */
   preventForwardScrubbing() {
-    if ((this.model.get('_preventForwardScrubbing')) && (!this.model.get('_isComplete'))) {
-      $(this.mediaElement).on({
-        seeking: this.onMediaElementSeeking,
-        timeupdate: this.onMediaElementTimeUpdate
-      });
-
-      const timeSlider = this.$('.mejs__time-slider')[0];
-      if (timeSlider) {
-        timeSlider.style.pointerEvents = 'none';
-        timeSlider.addEventListener('input', (e) => e.preventDefault());
-        timeSlider.setAttribute('aria-disabled', 'true');
-      }
+    if (!this.model.get('_preventForwardScrubbing') || this.model.get('_isComplete')) return;
+    $(this.mediaElement).on({
+      seeking: this.onMediaElementSeeking,
+      timeupdate: this.onMediaElementTimeUpdate
+    });
+    const timeSlider = this.$('.mejs__time-slider')[0];
+    if (timeSlider) {
+      timeSlider.style.pointerEvents = 'none';
+      timeSlider.addEventListener('input', (e) => e.preventDefault());
+      timeSlider.setAttribute('aria-disabled', 'true');
     }
   }
 

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -516,7 +516,7 @@ class MediaView extends ComponentView {
   }
 
   /**
-   * This function ensures that users cannot skip ahead in the media until they have watched it fully.
+   * This function ensures that users cannot skip ahead in the media until they have watched it fully if `_preventForwardScrubbing` is enabled.
    */
   preventForwardScrubbing() {
     if ((this.model.get('_preventForwardScrubbing')) && (!this.model.get('_isComplete'))) {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

It seems that learners are bypassing the `_preventForwardScrubbing` setting by interacting with the locked media player scrub bar. Despite the setting being enabled, a small number of learners repeatedly select the scrub bar and are able to skip forward in the video, essentially bypassing the need to watch the content in full.

The issue likely stems from the current solution, which forces the scrub bar to the furthest point of progress, but this approach isn't fully effective. A more robust solution would be to ensure that the locked scrub bar is not interactable or selectable at all.

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Fixes #319 
* No pointer events prevents mouse and touch events.
* Prevent default blocks the scrub bar from being changed programmatically.
* aria-disabled makes the scrub bar non-focusable.

I'm only taking a good stab at this being a good solution to truly lock down forward scrubbing. As stated in #319, I'm not sure how the current locks are being bypassed. 

[//]: # (List appropriate steps for testing if needed)
### Testing
Try to break it!

[//]: # (Mention any other dependencies)


