### PR TITLE
Update: "skip to transcript" styles to reflect latest core a11y (fixes #317)

### DIFF
--- a/less/media.less
+++ b/less/media.less
@@ -15,13 +15,7 @@
       .u-display-none;
     }
 
-    &:not(:focus-visible) {
-      display: block;
-      height: 0;
-      padding: 0;
-      margin: 0;
-      overflow: hidden;
-    }
+    .visually-hidden-focusable;
   }
 
   // Transcript container


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-media/issues/317

### Update
* Replaced `:focus-visible` styles with core mixin [`.visually-hidden-focusable`](https://github.com/adaptlearning/adapt-contrib-core/blob/d088744562af42232911f13391c47959d7dca415/less/core/accessibility.less#L36). To ensure consistency within Adapt when styling visually hidden / focused elements.

See [Core PR](https://github.com/adaptlearning/adapt-contrib-core/pull/611) for reference where accessible mixins were updated inline with latest best practice.

@simondate, this also addresses the [border issue](https://github.com/adaptlearning/adapt-contrib-media/issues/317#issuecomment-2846835640) you raised.


