### PR TITLE
Fix: Switch 'WebVTT source' AAT asset filter to 'other' (fixes #328)

### DIFF
--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -268,7 +268,7 @@
               "title": "Linked transcript file source",
               "_backboneForms": {
                 "type": "Asset",
-                "media": "text"
+                "media": "other"
               }
             }
           }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #328

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Allows all non audio/image/video files to be selectable in the AAT for the 'WebVTT source' field


