### PR TITLE
New: Add forward scrubbing prevention (fix #323)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If set to `true`, playback will automatically be paused when the media component
 
 ### \_preventForwardScrubbing (boolean)
 
-If set to `true`, learners will not be able to skip ahead in media (both audio and video) until they have watched/listened to it in full at least once. Learners can skip backwards, but only up to the furthest point they have previously reached. Note: This does not apply to full screen on iOS/iPadOS. Once the learner has completed the media component, this restriction will no longer be enforced. You should therefore ensure the `_setCompletionOn` setting is set to `"ended"` when using this setting. The default is `false`.
+If set to `true`, learners will not be able to skip ahead in media (both audio and video) until they have watched/listened to it in full at least once. Learners can skip backwards, but only up to the furthest point they have previously reached. Once the learner has completed the media component, this restriction will no longer be enforced. You should therefore ensure the `_setCompletionOn` setting is set to `"ended"` when using this setting. The default is `false`. Note: This feature may not work with native player controls.
 
 ### \_offsetMediaControls (boolean)
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If set to `true`, playback will automatically be paused when the media component
 
 ### \_preventForwardScrubbing (boolean)
 
-If set to `true`, the component will *attempt* to prevent learners from 'skipping ahead' in media (both audio and video).  Learners can skip backwards, and back up to the `maxViewed` time tracked by `updateTime`. Note: This does not apply to full screen iOS/iPadOs - and learners using certain browsers (Internet Explorer, for example) may be able to circumvent this rule by using video play speed options. Once the learner has completed the media component, this restriction will no longer be enforced. You should therefore ensure the `_setCompletionOn` setting is set to `"ended"` when using this setting.
+If set to `true`, learners will not be able to skip ahead in media (both audio and video) until they have watched/listened to it in full at least once. Learners can skip backwards, but only up to the furthest point they have previously reached. Note: This does not apply to full screen on iOS/iPadOS. Once the learner has completed the media component, this restriction will no longer be enforced. You should therefore ensure the `_setCompletionOn` setting is set to `"ended"` when using this setting. The default is `false`.
 
 ### \_offsetMediaControls (boolean)
 

--- a/example.json
+++ b/example.json
@@ -9,7 +9,7 @@
         "displayTitle": "Title of the media component",
         "body": "This is optional body text.",
         "instruction": "Select the play button to start the video.",
-        "_comment": "_setCompletionOn = inview | play | ended",
+        "_comment": "_setCompletionOn = inview | play | ended (must be 'ended' if using _preventForwardScrubbing)",
         "_setCompletionOn": "play",
         "_useClosedCaptions": true,
         "_allowFullScreen": true,

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -547,7 +547,6 @@ class MediaView extends ComponentView {
     // Create and setup the scrub blocker
     const scrubBlocker = this.createScrubBlocker($slider[0]);
 
-    // Setup event handlers
     this.setupScrubBlockerEvents(player, scrubBlocker, () => maxViewed, (newMax) => {
       maxViewed = newMax;
       this.model.set('_maxViewed', maxViewed);
@@ -563,7 +562,6 @@ class MediaView extends ComponentView {
     const scrubBlocker = document.createElement('div');
     scrubBlocker.className = 'mejs__time-slider-blocker';
 
-    // Setup flash animation
     const flashBlockedOverlay = () => {
       scrubBlocker.classList.add('mejs__time-slider-blocker-error');
       setTimeout(() => {
@@ -571,14 +569,12 @@ class MediaView extends ComponentView {
       }, 150);
     };
 
-    // Add interaction handling for blocked area
     scrubBlocker.addEventListener('pointerdown', (e) => {
       e.preventDefault();
       e.stopImmediatePropagation();
       flashBlockedOverlay();
     });
 
-    // Add click handler to the entire slider for navigation to maxViewed
     sliderElement.addEventListener('click', (e) => {
       const rect = sliderElement.getBoundingClientRect();
       const clickX = e.clientX - rect.left;
@@ -599,7 +595,6 @@ class MediaView extends ComponentView {
       }
     });
 
-    // Append to slider
     sliderElement.style.position = 'relative';
     sliderElement.appendChild(scrubBlocker);
     sliderElement.setAttribute('aria-disabled', 'true');
@@ -624,7 +619,6 @@ class MediaView extends ComponentView {
         player.currentTime = getMaxViewed();
         setSuppress(false);
 
-        // Flash the blocker to indicate restriction
         scrubBlocker.classList.add('mejs__time-slider-blocker-error');
         setTimeout(() => {
           scrubBlocker.classList.remove('mejs__time-slider-blocker-error');
@@ -640,10 +634,8 @@ class MediaView extends ComponentView {
       if (forwardKeys.includes(e.code) && player.currentTime >= getMaxViewed()) {
         e.preventDefault();
 
-        // Navigate to maxViewed when trying to use forward keys
         player.currentTime = getMaxViewed();
 
-        // Flash the blocker
         scrubBlocker.classList.add('mejs__time-slider-blocker-error');
         setTimeout(() => {
           scrubBlocker.classList.remove('mejs__time-slider-blocker-error');
@@ -651,7 +643,6 @@ class MediaView extends ComponentView {
       }
     });
 
-    // Cleanup when media ends
     player.addEventListener('ended', () => {
       this.model.set('_isComplete', true);
       scrubBlocker.remove();

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -571,7 +571,14 @@ class MediaView extends ComponentView {
       }, 150);
     };
 
-    // Listen to the entire slider to detect blocked area clicks
+    // Add interaction handling for blocked area
+    scrubBlocker.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      flashBlockedOverlay();
+    });
+
+    // Add click handler to the entire slider for navigation to maxViewed
     sliderElement.addEventListener('click', (e) => {
       const rect = sliderElement.getBoundingClientRect();
       const clickX = e.clientX - rect.left;
@@ -583,12 +590,10 @@ class MediaView extends ComponentView {
       const clickTime = clickPercent * duration;
       const maxViewed = this.model.get('_maxViewed') || 0;
 
-      // If clicking in the blocked area (beyond maxViewed)
+      // If clicking ahead of maxViewed, navigate to maxViewed and flash
       if (clickTime > maxViewed + 0.25) {
         e.preventDefault();
         e.stopImmediatePropagation();
-
-        // Navigate to maxViewed and flash
         player.currentTime = maxViewed;
         flashBlockedOverlay();
       }
@@ -603,7 +608,7 @@ class MediaView extends ComponentView {
   }
 
   setupScrubBlockerEvents(player, scrubBlocker, getMaxViewed, setMaxViewed, getSuppress, setSuppress) {
-    // Update progress and blocker size
+  // Update progress and blocker size
     player.addEventListener('timeupdate', () => {
       if (!getSuppress()) {
         const newMaxViewed = Math.max(getMaxViewed(), player.currentTime);

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -541,7 +541,7 @@ class MediaView extends ComponentView {
     const $slider = this.$('.mejs__time-slider');
     if (!$slider.length) return;
 
-    let maxViewed = this.model.get('_maxViewed') || 0;
+    let maxViewed = this.model.get('_maxViewed') ?? 0;
     let suppress = false;
 
     // Create and setup the scrub blocker
@@ -610,10 +610,7 @@ class MediaView extends ComponentView {
       player.currentTime = getMaxViewed();
       setSuppress(false);
 
-      scrubBlocker.classList.add('mejs__time-slider-blocker-error');
-      setTimeout(() => {
-        scrubBlocker.classList.remove('mejs__time-slider-blocker-error');
-      }, 150);
+      this.flashBlockedOverlay(scrubBlocker);
 
       this._showBlockedScrubMessage?.();
     });

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -7,6 +7,8 @@ import ComponentView from 'core/js/views/componentView';
 import 'libraries/mediaelement-and-player';
 import './mediaLibrariesOverrides';
 
+const FORWARD_SCRUBBING_KEYS = ['ArrowRight', 'End', 'PageDown'];
+
 // instruct adapt to wait whilst loading client-side libraries
 wait.for(async done => {
   // load plugins
@@ -445,9 +447,37 @@ class MediaView extends ComponentView {
         volumechange: this.onMediaVolumeChange
       });
 
+      // Clean up forward scrubbing prevention listeners
+      if (this._onScrubTimeUpdate) {
+        this.mediaElement.removeEventListener('timeupdate', this._onScrubTimeUpdate);
+      }
+      if (this._onScrubSeeking) {
+        this.mediaElement.removeEventListener('seeking', this._onScrubSeeking);
+      }
+      if (this._onScrubKeyDown) {
+        this.mediaElement.removeEventListener('keydown', this._onScrubKeyDown);
+      }
+      if (this._onScrubEnded) {
+        this.mediaElement.removeEventListener('ended', this._onScrubEnded);
+      }
+
       this.mediaElement.src = '';
       $(this.mediaElement.pluginElement).remove();
       delete this.mediaElement;
+    }
+
+    // Clean up scrub blocker DOM element and listeners
+    if (this._scrubBlocker) {
+      if (this._onBlockerPointerDown) {
+        this._scrubBlocker.removeEventListener('pointerdown', this._onBlockerPointerDown);
+      }
+      this._scrubBlocker.remove();
+      delete this._scrubBlocker;
+    }
+
+    const $slider = this.$('.mejs__time-slider');
+    if ($slider.length && this._onSliderClick) {
+      $slider[0].removeEventListener('click', this._onSliderClick);
     }
 
     super.remove();
@@ -535,57 +565,54 @@ class MediaView extends ComponentView {
    * This function ensures that users cannot skip ahead in the media until they have watched it fully if `_preventForwardScrubbing` is enabled.
    */
   preventForwardScrubbing() {
-    if (!this.model.get('_preventForwardScrubbing') || this.model.get('_isComplete')) return;
+    const isEnabled = this.model.get('_preventForwardScrubbing');
+    const isComplete = this.model.get('_isComplete');
+    if (!isEnabled || isComplete) return;
 
-    const player = this.mediaElement;
     const $slider = this.$('.mejs__time-slider');
     if (!$slider.length) return;
 
-    let maxViewed = this.model.get('_maxViewed') ?? 0;
-    let suppress = false;
+    this._maxViewed = this.model.get('_maxViewed') ?? 0;
+    this._suppressSeek = false;
 
     // Create and setup the scrub blocker
-    const scrubBlocker = this.createScrubBlocker($slider[0]);
+    this._scrubBlocker = this.createScrubBlocker($slider[0]);
 
-    this.setupScrubBlockerEvents(player, scrubBlocker, () => maxViewed, (newMax) => {
-      maxViewed = newMax;
-      this.model.set('_maxViewed', maxViewed);
-    }, () => suppress, (newSuppress) => {
-      suppress = newSuppress;
-    });
+    this.setupScrubBlockerEvents();
 
     // Initialize the blocker size
-    this.updateScrubBlocker(scrubBlocker, player, maxViewed);
+    this.updateScrubBlocker();
   }
 
   createScrubBlocker(sliderElement) {
     const scrubBlocker = document.createElement('span');
     scrubBlocker.className = 'mejs__time-slider-blocker';
 
-    scrubBlocker.addEventListener('pointerdown', (e) => {
+    this._onBlockerPointerDown = (e) => {
       e.preventDefault();
       e.stopImmediatePropagation();
       this.flashBlockedOverlay(scrubBlocker);
-    });
+    };
 
-    sliderElement.addEventListener('click', (e) => {
+    this._onSliderClick = (e) => {
       const rect = sliderElement.getBoundingClientRect();
       const clickX = e.clientX - rect.left;
       const sliderWidth = rect.width;
       const clickPercent = clickX / sliderWidth;
-
-      const player = this.mediaElement;
-      const duration = player.duration;
+      const duration = this.mediaElement.duration;
       const clickTime = clickPercent * duration;
-      const maxViewed = this.model.get('_maxViewed') || 0;
+      const isClickingAhead = clickTime > this._maxViewed + 0.25;
 
-      // If clicking ahead of maxViewed, navigate to maxViewed and flash
-      if (clickTime <= maxViewed + 0.25) return;
+      if (!isClickingAhead) return;
+
       e.preventDefault();
       e.stopImmediatePropagation();
-      player.currentTime = maxViewed;
+      this.mediaElement.currentTime = this._maxViewed;
       this.flashBlockedOverlay(scrubBlocker);
-    });
+    };
+
+    scrubBlocker.addEventListener('pointerdown', this._onBlockerPointerDown);
+    sliderElement.addEventListener('click', this._onSliderClick);
 
     sliderElement.style.position = 'relative';
     sliderElement.appendChild(scrubBlocker);
@@ -594,42 +621,50 @@ class MediaView extends ComponentView {
     return scrubBlocker;
   }
 
-  setupScrubBlockerEvents(player, scrubBlocker, getMaxViewed, setMaxViewed, getSuppress, setSuppress) {
+  setupScrubBlockerEvents() {
     // Update progress and blocker size
-    player.addEventListener('timeupdate', () => {
-      if (getSuppress()) return;
-      const newMaxViewed = Math.max(getMaxViewed(), player.currentTime);
-      setMaxViewed(newMaxViewed);
-      this.updateScrubBlocker(scrubBlocker, player, newMaxViewed);
-    });
+    this._onScrubTimeUpdate = () => {
+      if (this._suppressSeek) return;
+      this._maxViewed = Math.max(this._maxViewed, this.mediaElement.currentTime);
+      this.model.set('_maxViewed', this._maxViewed);
+      this.updateScrubBlocker();
+    };
 
     // Prevent forward seeking and navigate to maxViewed
-    player.addEventListener('seeking', () => {
-      if (player.currentTime <= getMaxViewed() + 0.25) return;
-      setSuppress(true);
-      player.currentTime = getMaxViewed();
-      setSuppress(false);
+    this._onScrubSeeking = () => {
+      const isSeekingAhead = this.mediaElement.currentTime > this._maxViewed + 0.25;
+      if (!isSeekingAhead) return;
 
-      this.flashBlockedOverlay(scrubBlocker);
+      this._suppressSeek = true;
+      this.mediaElement.currentTime = this._maxViewed;
+      this._suppressSeek = false;
 
+      this.flashBlockedOverlay(this._scrubBlocker);
       this._showBlockedScrubMessage?.();
-    });
+    };
 
     // Prevent keyboard forward navigation
-    player.addEventListener('keydown', (e) => {
-      const forwardKeys = ['ArrowRight', 'End', 'PageDown'];
-      if (!forwardKeys.includes(e.code) || player.currentTime < getMaxViewed()) return;
+    this._onScrubKeyDown = (e) => {
+      const isForwardKey = FORWARD_SCRUBBING_KEYS.includes(e.code);
+      const isAtMaxViewed = this.mediaElement.currentTime >= this._maxViewed;
+      const shouldPrevent = isForwardKey && isAtMaxViewed;
+
+      if (!shouldPrevent) return;
+
       e.preventDefault();
+      this.mediaElement.currentTime = this._maxViewed;
+      this.flashBlockedOverlay(this._scrubBlocker);
+    };
 
-      player.currentTime = getMaxViewed();
-
-      this.flashBlockedOverlay(scrubBlocker);
-    });
-
-    player.addEventListener('ended', () => {
+    this._onScrubEnded = () => {
       this.model.set('_isComplete', true);
-      scrubBlocker.remove();
-    });
+      this._scrubBlocker?.remove();
+    };
+
+    this.mediaElement.addEventListener('timeupdate', this._onScrubTimeUpdate);
+    this.mediaElement.addEventListener('seeking', this._onScrubSeeking);
+    this.mediaElement.addEventListener('keydown', this._onScrubKeyDown);
+    this.mediaElement.addEventListener('ended', this._onScrubEnded);
   }
 
   flashBlockedOverlay(e) {
@@ -639,12 +674,15 @@ class MediaView extends ComponentView {
     }, 150);
   }
 
-  updateScrubBlocker(scrubBlocker, player, maxViewed) {
-    const duration = player.duration;
-    if (!duration || duration === Infinity) return;
+  updateScrubBlocker() {
+    if (!this._scrubBlocker) return;
 
-    const percentViewed = 1 - maxViewed / duration;
-    scrubBlocker.style.width = `${percentViewed * 100}%`;
+    const duration = this.mediaElement.duration;
+    const isValidDuration = duration && duration !== Infinity;
+    if (!isValidDuration) return;
+
+    const percentViewed = 1 - this._maxViewed / duration;
+    this._scrubBlocker.style.width = `${percentViewed * 100}%`;
   }
 
   /**

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -51,10 +51,10 @@ class MediaView extends ComponentView {
       'media:stop': this.onMediaStop
     });
 
-    // android, force timeupdate handler to call after seeking handler in order to prevent forward scrubbing
-    this.onMediaElementTimeUpdate = _.debounce(this.onMediaElementTimeUpdate.bind(this), 0);
-
-    _.bindAll(this, 'onMediaElementPlay', 'onMediaElementPause', 'onMediaElementEnded', 'onMediaVolumeChange', 'onMediaElementSeeking', 'onOverlayClick', 'onMediaElementClick', 'onWidgetInview');
+    _.bindAll(this,
+      'onMediaElementPlay', 'onMediaElementPause', 'onMediaElementEnded', 'onMediaVolumeChange', 'onOverlayClick', 'onMediaElementClick', 'onWidgetInview',
+      'onScrubTimeUpdate', 'onScrubSeeking', 'onScrubKeyDown', 'onScrubEnded', 'onBlockerPointerDown', 'onSliderClick', 'onCaptionsChange'
+    );
 
     // set initial player state attributes
     this.model.set({
@@ -253,12 +253,7 @@ class MediaView extends ComponentView {
     if (!this.model.get('_useClosedCaptions')) return;
     this.setCaptionButtonState();
 
-    this.mediaElement.addEventListener('captionschange', event => {
-      const srclang = this.mediaElementInstance.selectedTrack ? this.mediaElementInstance.selectedTrack.srclang : 'none';
-      offlineStorage.set('captions', srclang);
-      Adapt.trigger('media:captionsChange', this, srclang);
-      this.setCaptionButtonState();
-    });
+    this.mediaElement.addEventListener('captionschange', this.onCaptionsChange);
 
     this.listenTo(Adapt, 'media:captionsChange', this.onCaptionsChanged);
   }
@@ -294,6 +289,15 @@ class MediaView extends ComponentView {
     const srclang = this.mediaElementInstance.selectedTrack ? this.mediaElementInstance.selectedTrack.srclang : 'none';
     const $ccButton = this.$el.find('.mejs__captions-button > button');
     $ccButton.attr('aria-pressed', srclang !== 'none');
+  }
+
+  onCaptionsChange() {
+    const srclang = this.mediaElementInstance.selectedTrack
+      ? this.mediaElementInstance.selectedTrack.srclang
+      : 'none';
+    offlineStorage.set('captions', srclang);
+    Adapt.trigger('media:captionsChange', this, srclang);
+    this.setCaptionButtonState();
   }
 
   /**
@@ -352,26 +356,6 @@ class MediaView extends ComponentView {
 
   onWidgetInview(event, isInView) {
     if (!isInView && !this.mediaElement.paused) this.mediaElement.pause();
-  }
-
-  onMediaElementSeeking(event) {
-    let maxViewed = this.model.get('_maxViewed');
-    if (!maxViewed) {
-      maxViewed = 0;
-    }
-    const target = event.currentTarget;
-    if (target.currentTime <= maxViewed) return;
-    target.currentTime = maxViewed;
-  }
-
-  onMediaElementTimeUpdate(event) {
-    let maxViewed = this.model.get('_maxViewed');
-    if (!maxViewed) {
-      maxViewed = 0;
-    }
-    const target = event.currentTarget;
-    if (target.currentTime <= maxViewed) return;
-    this.model.set('_maxViewed', target.currentTime);
   }
 
   onMediaStop(view) {
@@ -442,16 +426,15 @@ class MediaView extends ComponentView {
         play: this.onMediaElementPlay,
         pause: this.onMediaElementPause,
         ended: this.onMediaElementEnded,
-        seeking: this.onMediaElementSeeking,
-        timeupdate: this.onMediaElementTimeUpdate,
         volumechange: this.onMediaVolumeChange
       });
 
       // Clean up forward scrubbing prevention listeners
-      this.mediaElement.removeEventListener('timeupdate', this._onScrubTimeUpdate);
-      this.mediaElement.removeEventListener('seeking', this._onScrubSeeking);
-      this.mediaElement.removeEventListener('keydown', this._onScrubKeyDown);
-      this.mediaElement.removeEventListener('ended', this._onScrubEnded);
+      this.mediaElement.removeEventListener('timeupdate', this.onScrubTimeUpdate);
+      this.mediaElement.removeEventListener('seeking', this.onScrubSeeking);
+      this.mediaElement.removeEventListener('keydown', this.onScrubKeyDown);
+      this.mediaElement.removeEventListener('ended', this.onScrubEnded);
+      this.mediaElement.removeEventListener('captionschange', this.onCaptionsChange);
 
       this.mediaElement.src = '';
       $(this.mediaElement.pluginElement).remove();
@@ -460,16 +443,14 @@ class MediaView extends ComponentView {
 
     // Clean up scrub blocker DOM element and listeners
     if (this._scrubBlocker) {
-      if (this._onBlockerPointerDown) {
-        this._scrubBlocker.removeEventListener('pointerdown', this._onBlockerPointerDown);
-      }
+      this._scrubBlocker.removeEventListener('pointerdown', this.onBlockerPointerDown);
       this._scrubBlocker.remove();
       delete this._scrubBlocker;
     }
 
-    const $slider = this.$('.mejs__time-slider');
-    if ($slider.length && this._onSliderClick) {
-      $slider[0].removeEventListener('click', this._onSliderClick);
+    if (this._sliderElement) {
+      this._sliderElement.removeEventListener('click', this.onSliderClick);
+      delete this._sliderElement;
     }
 
     super.remove();
@@ -576,14 +557,30 @@ class MediaView extends ComponentView {
     this.updateScrubBlocker();
   }
   
-  _onBlockerPointerDown (e) {
-    e.preventDefault();
-    e.stopImmediatePropagation();
-    this.flashBlockedOverlay(scrubBlocker);
+  createScrubBlocker(sliderElement) {
+    this._sliderElement = sliderElement;
+
+    const scrubBlocker = document.createElement('span');
+    scrubBlocker.className = 'mejs__time-slider-blocker';
+
+    scrubBlocker.addEventListener('pointerdown', this.onBlockerPointerDown);
+    sliderElement.addEventListener('click', this.onSliderClick);
+
+    sliderElement.style.position = 'relative';
+    sliderElement.appendChild(scrubBlocker);
+    sliderElement.setAttribute('aria-disabled', 'true');
+
+    return scrubBlocker;
   }
 
-  _onSliderClick (e) {
-    const rect = sliderElement.getBoundingClientRect();
+  onBlockerPointerDown(e) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    this.flashBlockedOverlay(this._scrubBlocker);
+  }
+
+  onSliderClick(e) {
+    const rect = this._sliderElement.getBoundingClientRect();
     const clickX = e.clientX - rect.left;
     const sliderWidth = rect.width;
     const clickPercent = clickX / sliderWidth;
@@ -596,24 +593,18 @@ class MediaView extends ComponentView {
     e.preventDefault();
     e.stopImmediatePropagation();
     this.mediaElement.currentTime = this._maxViewed;
-    this.flashBlockedOverlay(scrubBlocker);
+    this.flashBlockedOverlay(this._scrubBlocker);
   }
 
-  createScrubBlocker(sliderElement) {
-    const scrubBlocker = document.createElement('span');
-    scrubBlocker.className = 'mejs__time-slider-blocker';
-
-    scrubBlocker.addEventListener('pointerdown', this._onBlockerPointerDown);
-    sliderElement.addEventListener('click', this._onSliderClick);
-
-    sliderElement.style.position = 'relative';
-    sliderElement.appendChild(scrubBlocker);
-    sliderElement.setAttribute('aria-disabled', 'true');
-
-    return scrubBlocker;
+  setupScrubBlockerEvents() {
+    this.mediaElement.addEventListener('timeupdate', this.onScrubTimeUpdate);
+    this.mediaElement.addEventListener('seeking', this.onScrubSeeking);
+    this.mediaElement.addEventListener('keydown', this.onScrubKeyDown);
+    this.mediaElement.addEventListener('ended', this.onScrubEnded);
   }
-  
-  onScrubTimeUpdate () {
+
+  // Update progress and blocker size
+  onScrubTimeUpdate() {
     if (this._suppressSeek) return;
     this._maxViewed = Math.max(this._maxViewed, this.mediaElement.currentTime);
     this.model.set('_maxViewed', this._maxViewed);
@@ -621,20 +612,21 @@ class MediaView extends ComponentView {
   }
 
   // Prevent forward seeking and navigate to maxViewed
-  onScrubSeeking () {
+  onScrubSeeking() {
     const isSeekingAhead = this.mediaElement.currentTime > this._maxViewed + 0.25;
     if (!isSeekingAhead) return;
 
     this._suppressSeek = true;
+    this.mediaElement.addEventListener('seeked', () => {
+      this._suppressSeek = false;
+    }, { once: true });
     this.mediaElement.currentTime = this._maxViewed;
-    this._suppressSeek = false;
 
     this.flashBlockedOverlay(this._scrubBlocker);
-    this._showBlockedScrubMessage?.();
   }
 
   // Prevent keyboard forward navigation
-  _onScrubKeyDown (e) {
+  onScrubKeyDown(e) {
     const isForwardKey = FORWARD_SCRUBBING_KEYS.includes(e.code);
     const isAtMaxViewed = this.mediaElement.currentTime >= this._maxViewed;
     const shouldPrevent = isForwardKey && isAtMaxViewed;
@@ -646,23 +638,15 @@ class MediaView extends ComponentView {
     this.flashBlockedOverlay(this._scrubBlocker);
   }
 
-  _onScrubEnded () {
-    this.model.set('_isComplete', true);
+  onScrubEnded() {
+    this.setCompletionStatus();
     this._scrubBlocker?.remove();
   }
 
-  setupScrubBlockerEvents() {
-    // Update progress and blocker size
-    this.mediaElement.addEventListener('timeupdate', this._onScrubTimeUpdate);
-    this.mediaElement.addEventListener('seeking', this._onScrubSeeking);
-    this.mediaElement.addEventListener('keydown', this._onScrubKeyDown);
-    this.mediaElement.addEventListener('ended', this._onScrubEnded);
-  }
-
-  flashBlockedOverlay(e) {
-    e.classList.add('mejs__time-slider-blocker-error');
+  flashBlockedOverlay(element) {
+    element.classList.add('mejs__time-slider-blocker-error');
     setTimeout(() => {
-      e.classList.remove('mejs__time-slider-blocker-error');
+      element.classList.remove('mejs__time-slider-blocker-error');
     }, 150);
   }
 

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -448,18 +448,10 @@ class MediaView extends ComponentView {
       });
 
       // Clean up forward scrubbing prevention listeners
-      if (this._onScrubTimeUpdate) {
-        this.mediaElement.removeEventListener('timeupdate', this._onScrubTimeUpdate);
-      }
-      if (this._onScrubSeeking) {
-        this.mediaElement.removeEventListener('seeking', this._onScrubSeeking);
-      }
-      if (this._onScrubKeyDown) {
-        this.mediaElement.removeEventListener('keydown', this._onScrubKeyDown);
-      }
-      if (this._onScrubEnded) {
-        this.mediaElement.removeEventListener('ended', this._onScrubEnded);
-      }
+      this.mediaElement.removeEventListener('timeupdate', this._onScrubTimeUpdate);
+      this.mediaElement.removeEventListener('seeking', this._onScrubSeeking);
+      this.mediaElement.removeEventListener('keydown', this._onScrubKeyDown);
+      this.mediaElement.removeEventListener('ended', this._onScrubEnded);
 
       this.mediaElement.src = '';
       $(this.mediaElement.pluginElement).remove();

--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -575,33 +575,33 @@ class MediaView extends ComponentView {
     // Initialize the blocker size
     this.updateScrubBlocker();
   }
+  
+  _onBlockerPointerDown (e) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    this.flashBlockedOverlay(scrubBlocker);
+  }
+
+  _onSliderClick (e) {
+    const rect = sliderElement.getBoundingClientRect();
+    const clickX = e.clientX - rect.left;
+    const sliderWidth = rect.width;
+    const clickPercent = clickX / sliderWidth;
+    const duration = this.mediaElement.duration;
+    const clickTime = clickPercent * duration;
+    const isClickingAhead = clickTime > this._maxViewed + 0.25;
+
+    if (!isClickingAhead) return;
+
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    this.mediaElement.currentTime = this._maxViewed;
+    this.flashBlockedOverlay(scrubBlocker);
+  }
 
   createScrubBlocker(sliderElement) {
     const scrubBlocker = document.createElement('span');
     scrubBlocker.className = 'mejs__time-slider-blocker';
-
-    this._onBlockerPointerDown = (e) => {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      this.flashBlockedOverlay(scrubBlocker);
-    };
-
-    this._onSliderClick = (e) => {
-      const rect = sliderElement.getBoundingClientRect();
-      const clickX = e.clientX - rect.left;
-      const sliderWidth = rect.width;
-      const clickPercent = clickX / sliderWidth;
-      const duration = this.mediaElement.duration;
-      const clickTime = clickPercent * duration;
-      const isClickingAhead = clickTime > this._maxViewed + 0.25;
-
-      if (!isClickingAhead) return;
-
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      this.mediaElement.currentTime = this._maxViewed;
-      this.flashBlockedOverlay(scrubBlocker);
-    };
 
     scrubBlocker.addEventListener('pointerdown', this._onBlockerPointerDown);
     sliderElement.addEventListener('click', this._onSliderClick);
@@ -612,47 +612,47 @@ class MediaView extends ComponentView {
 
     return scrubBlocker;
   }
+  
+  onScrubTimeUpdate () {
+    if (this._suppressSeek) return;
+    this._maxViewed = Math.max(this._maxViewed, this.mediaElement.currentTime);
+    this.model.set('_maxViewed', this._maxViewed);
+    this.updateScrubBlocker();
+  }
+
+  // Prevent forward seeking and navigate to maxViewed
+  onScrubSeeking () {
+    const isSeekingAhead = this.mediaElement.currentTime > this._maxViewed + 0.25;
+    if (!isSeekingAhead) return;
+
+    this._suppressSeek = true;
+    this.mediaElement.currentTime = this._maxViewed;
+    this._suppressSeek = false;
+
+    this.flashBlockedOverlay(this._scrubBlocker);
+    this._showBlockedScrubMessage?.();
+  }
+
+  // Prevent keyboard forward navigation
+  _onScrubKeyDown (e) {
+    const isForwardKey = FORWARD_SCRUBBING_KEYS.includes(e.code);
+    const isAtMaxViewed = this.mediaElement.currentTime >= this._maxViewed;
+    const shouldPrevent = isForwardKey && isAtMaxViewed;
+
+    if (!shouldPrevent) return;
+
+    e.preventDefault();
+    this.mediaElement.currentTime = this._maxViewed;
+    this.flashBlockedOverlay(this._scrubBlocker);
+  }
+
+  _onScrubEnded () {
+    this.model.set('_isComplete', true);
+    this._scrubBlocker?.remove();
+  }
 
   setupScrubBlockerEvents() {
     // Update progress and blocker size
-    this._onScrubTimeUpdate = () => {
-      if (this._suppressSeek) return;
-      this._maxViewed = Math.max(this._maxViewed, this.mediaElement.currentTime);
-      this.model.set('_maxViewed', this._maxViewed);
-      this.updateScrubBlocker();
-    };
-
-    // Prevent forward seeking and navigate to maxViewed
-    this._onScrubSeeking = () => {
-      const isSeekingAhead = this.mediaElement.currentTime > this._maxViewed + 0.25;
-      if (!isSeekingAhead) return;
-
-      this._suppressSeek = true;
-      this.mediaElement.currentTime = this._maxViewed;
-      this._suppressSeek = false;
-
-      this.flashBlockedOverlay(this._scrubBlocker);
-      this._showBlockedScrubMessage?.();
-    };
-
-    // Prevent keyboard forward navigation
-    this._onScrubKeyDown = (e) => {
-      const isForwardKey = FORWARD_SCRUBBING_KEYS.includes(e.code);
-      const isAtMaxViewed = this.mediaElement.currentTime >= this._maxViewed;
-      const shouldPrevent = isForwardKey && isAtMaxViewed;
-
-      if (!shouldPrevent) return;
-
-      e.preventDefault();
-      this.mediaElement.currentTime = this._maxViewed;
-      this.flashBlockedOverlay(this._scrubBlocker);
-    };
-
-    this._onScrubEnded = () => {
-      this.model.set('_isComplete', true);
-      this._scrubBlocker?.remove();
-    };
-
     this.mediaElement.addEventListener('timeupdate', this._onScrubTimeUpdate);
     this.mediaElement.addEventListener('seeking', this._onScrubSeeking);
     this.mediaElement.addEventListener('keydown', this._onScrubKeyDown);

--- a/less/mediaelementplayer.less
+++ b/less/mediaelementplayer.less
@@ -511,23 +511,6 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
     width: 0;
 }
 
-.mejs__time-slider-blocker {
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: 100%;
-  width: 0;
-  background-color: transparent;
-  pointer-events: auto;
-  z-index: 9999;
-  cursor: not-allowed;
-  transition: background-color 0.15s ease;
-  
-  &.mejs__time-slider-blocker-error {
-    background-color: fade(@validation-error, 30%);
-  }
-}
-
 .mejs__long-video .mejs__time-float {
     margin-left: -1.4375rem;
     width: 4rem;

--- a/less/mediaelementplayer.less
+++ b/less/mediaelementplayer.less
@@ -511,6 +511,23 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
     width: 0;
 }
 
+.mejs__time-slider-blocker {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 0;
+  background-color: transparent;
+  pointer-events: auto;
+  z-index: 9999;
+  cursor: not-allowed;
+  transition: background-color 0.15s ease;
+  
+  &.mejs__time-slider-blocker-error {
+    background-color: fade(@validation-error, 30%);
+  }
+}
+
 .mejs__long-video .mejs__time-float {
     margin-left: -1.4375rem;
     width: 4rem;

--- a/less/mep-overrides.less
+++ b/less/mep-overrides.less
@@ -26,3 +26,22 @@
 .mejs__button.mejs__jump-forward-button > button {
   background-size: contain;
 }
+
+// Time slider blocker for validation errors
+// --------------------------------------------------
+.mejs__time-slider-blocker {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 0;
+  background-color: transparent;
+  pointer-events: auto;
+  z-index: 9999;
+  cursor: not-allowed;
+  transition: background-color 0.15s ease;
+  
+  &.mejs__time-slider-blocker-error {
+    background-color: fade(@validation-error, 30%);
+  }
+}

--- a/properties.schema
+++ b/properties.schema
@@ -366,10 +366,10 @@
       "type": "boolean",
       "required": false,
       "default": false,
-      "title": "Attempt to prevent media scrubbing?",
+      "title": "Prevent media scrubbing?",
       "inputType": "Checkbox",
       "validators": [],
-      "help": "If enabled, will attempt to prevent users from skipping ahead in audio/video."
+      "help": "If enabled, learners will not be able to skip ahead in audio/video until they have watched/listened to it in full at least once. Ensure '_setCompletionOn' is set to 'ended' when using this setting."
     },
     "_offsetMediaControls": {
       "type": "boolean",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -200,8 +200,8 @@
         },
         "_preventForwardScrubbing": {
           "type": "boolean",
-          "title": "Attempt to prevent media scrubbing",
-          "description": "If enabled, will attempt to prevent users from skipping ahead in audio/video",
+          "title": "Prevent media scrubbing?",
+          "description": "If enabled, learners will not be able to skip ahead in audio/video until they have watched/listened to it in full at least once. Ensure '_setCompletionOn' is set to 'ended' when using this setting.",
           "default": false
         },
         "_offsetMediaControls": {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
https://github.com/adaptlearning/adapt-contrib-media/pull/320 - was not a comprehensive solution for preventing forward scrubbing. Making another attempt.

### Fix
- Fixes #323 
- Fixes #333
- No pointer events prevents mouse and touch events.
- Prevent default blocks the scrub bar from being changed programmatically.
- aria-disabled makes the scrub bar non-focusable.
- Prevents events from firing when attempting to scrub passed a locked segment of the video.

### Update
- Adjusted `_preventForwardScrubbing` configuration option that prevents learners from skipping ahead in audio/video content until they have viewed/listened to it completely at least once
- Learners can still skip backwards to any previously viewed portion of the media
- Visual blocker overlay appears on the progress bar to indicate the restricted area. Animation provides feedback when learners attempt to scrub forward beyond their max viewed position
- Keyboard navigation (ArrowRight, End, PageDown) is also restricted when at the maximum viewed position
- Restriction is automatically lifted once the component is marked as complete
- Event listener management for forward scrubbing prevention to ensure proper cleanup on component removal
- README, Schemas & Example

### New

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Enable `_preventForwardScrubbing: true` in a media component
2. Set `_setCompletionOn: "ended"`
3. Play the media and verify:
  - You cannot click or drag the progress bar ahead of the current max viewed position
  - You can click/drag backwards to any previously viewed position
  - Arrow keys (ArrowRight, End, PageDown) do not skip ahead when at max viewed position
  - A visual blocker appears on the progress bar showing the restricted area
  - Flash animation displays when attempting to scrub forward
  - After reaching the end and completing the component, all restrictions are removed
4. Test with both audio and video media
5. Verify proper cleanup by navigating away from the page and back

[//]: # (Mention any other dependencies)


