### PR TITLE
Fix: Apply completion aria label to transcript button (fixes #337)

### DIFF
--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -324,6 +324,7 @@ class MediaView extends ComponentView {
 
     if (this.completionEvent !== 'play') return;
     this.setCompletionStatus();
+    this.setTranscriptCompletionAria();
   }
 
   onMediaElementPause(event) {
@@ -341,6 +342,7 @@ class MediaView extends ComponentView {
 
     if (this.completionEvent === 'ended') {
       this.setCompletionStatus();
+      this.setTranscriptCompletionAria();
     }
   }
 
@@ -528,7 +530,14 @@ class MediaView extends ComponentView {
       return Adapt.trigger('media:transcript', state, this);
     }
     this.setCompletionStatus();
+    this.setTranscriptCompletionAria();
     Adapt.trigger('media:transcript', 'complete', this);
+  }
+
+  setTranscriptCompletionAria() {
+    // apply completion aria label to transcript button
+    const completedLabel = `${this.model.get('_globals')._accessibility._ariaLabels.complete}. `;
+    this.$('.media__transcript-btn').prepend($('<span class="aria-label">' + completedLabel + '</span>'));
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-media/issues/337

### Fix
* Apply completion aria label to transcript button when Media completes. 
* This provides the screen reader equivalent of the visual tick icon and is consistent with other completed items/buttons.

<img width="316" height="144" alt="Image" src="https://github.com/user-attachments/assets/ea9742bf-3343-414b-b2ee-cb7e3ef5246b" />

### Testing
1. With a screen reader running, complete the Media component by either opening the transcript or playing the video.
2. When focus is one the transcript button, this should announce "Completed. Transcript" / "Completed. Close Transcript" or equivalent.


