### PR TITLE
Fix: Corrected classes used for targeting in tests to the newer structure

### DIFF
--- a/test/e2e/media.cy.js
+++ b/test/e2e/media.cy.js
@@ -14,10 +14,10 @@ describe('Media', function () {
       cy.testContainsOrNotExists('.media__instruction', stripHtml(mediaComponent.instruction));
 
       if (mediaComponent._media.mp4) {
-        cy.get('.mejs-mediaelement video').should('have.attr', 'src', mediaComponent._media.mp4);
+        cy.get('.mejs__mediaelement video').should('have.attr', 'src', mediaComponent._media.mp4);
       };
       if (mediaComponent._media.poster) {
-        cy.get('.mejs-poster img').should('have.attr', 'src', mediaComponent._media.poster);
+        cy.get('.mejs__poster img').should('have.attr', 'src', mediaComponent._media.poster);
       };
 
       if (mediaComponent._transcript) {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #339 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Corrected classes used for targeting in tests to the newer structure