### PR TITLE
Fix: invoke shouldSetSize() instead of storing method reference (fixes #359)

### DIFF
--- a/js/mediaView.js
+++ b/js/mediaView.js
@@ -58,7 +58,7 @@ class MediaView extends ComponentView {
     this.model.set({
       _isMediaEnded: false,
       _isMediaPlaying: false,
-      _shouldSetSize: this.shouldSetSize
+      _shouldSetSize: this.shouldSetSize()
     });
 
     if (!this.model.get('_media').source) return;


### PR DESCRIPTION
Closes #359

### Fix
* Add missing parentheses to invoke `shouldSetSize()` in `preRender()`. Previously, `this.shouldSetSize` stored the method reference (always truthy) rather than calling it, so `_shouldSetSize` was never computed correctly and explicit `width`/`height` were always set on the `<video>` element regardless of native control settings.

### Testing
1. Configure a media component with `_playerOptions.iPhoneUseNativeControls: true` (or the iPad/Android equivalents)
2. View on the corresponding device
3. Confirm no explicit `width`/`height` attributes are set on the `<video>` element when native controls are active
4. Confirm dimensions are still set correctly on devices/configs where native controls are not enabled